### PR TITLE
test: cover knowledge graph domain invariants

### DIFF
--- a/packages/server-knowledge/src/domain/confidence.value-object.test.ts
+++ b/packages/server-knowledge/src/domain/confidence.value-object.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+
+import { Confidence } from "./confidence.value-object.ts";
+
+test("Confidence.create: given the lower bound 0, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = Confidence.create(0);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("Confidence.create: given the upper bound 1, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = Confidence.create(1);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("Confidence.create: given a value within the range, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = Confidence.create(0.42);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("Confidence.create: given a value above 1, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN / WHEN
+  const result = Confidence.create(1.01);
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+  expect(result.error.category).toBe("validation");
+});
+
+test("Confidence.create: given a value below 0, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN / WHEN
+  const result = Confidence.create(-0.01);
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+});
+
+test("Confidence.restore: given a stored value, it should equal the same Confidence.create value", () => {
+  // GIVEN
+  const created = Confidence.create(0.5);
+  if (!created.ok) throw new Error("expected ok");
+
+  // WHEN / THEN
+  expect(Confidence.restore(0.5).equals(created.value)).toBe(true);
+});
+
+test("Confidence.restore: given an out-of-range value, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() => Confidence.restore(2)).toThrow();
+});

--- a/packages/server-knowledge/src/domain/embedding.value-object.test.ts
+++ b/packages/server-knowledge/src/domain/embedding.value-object.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+
+import { Embedding } from "./embedding.value-object.ts";
+
+test("Embedding.create: given a non-empty vector, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = Embedding.create([0.1, 0.2, 0.3], "text-embedding-3-small");
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("Embedding.create: given a vector, it should derive dimensions from the vector length", () => {
+  // GIVEN
+  const created = Embedding.create([0.1, 0.2, 0.3], "text-embedding-3-small");
+  if (!created.ok) throw new Error("expected ok");
+
+  // WHEN / THEN
+  expect(
+    created.value.equals(
+      Embedding.restore([0.1, 0.2, 0.3], "text-embedding-3-small", 3),
+    ),
+  ).toBe(true);
+});
+
+test("Embedding.create: given an empty vector, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = Embedding.create([], "text-embedding-3-small");
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+  expect(result.error.category).toBe("validation");
+});
+
+test("Embedding.create: given a blank model, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = Embedding.create([0.1, 0.2], "   ");
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+});
+
+test("Embedding.restore: given non-positive dimensions, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() => Embedding.restore([0.1], "text-embedding-3-small", 0)).toThrow();
+});
+
+test("Embedding.restore: given an empty vector, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() => Embedding.restore([], "text-embedding-3-small", 1)).toThrow();
+});

--- a/packages/server-knowledge/src/domain/knowledge-graph-edge.aggregate.test.ts
+++ b/packages/server-knowledge/src/domain/knowledge-graph-edge.aggregate.test.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "bun:test";
+
+import { EventId } from "./event-id.value-object.ts";
+import { KnowledgeGraphEdge } from "./knowledge-graph-edge.aggregate.ts";
+import { KnowledgeGraphId } from "./knowledge-graph-id.value-object.ts";
+import { NodeId } from "./node-id.value-object.ts";
+
+const now = new Date("2026-01-02T00:00:00Z");
+const observedAt = new Date("2026-01-01T00:00:00Z");
+
+const validInput = {
+  graphId: KnowledgeGraphId.create(),
+  fromId: NodeId.create(),
+  toId: NodeId.create(),
+  relationship: "MENTIONS" as const,
+  confidence: 0.9,
+  sourceEventIds: [EventId.create()],
+  observedAt,
+  now,
+};
+
+test("KnowledgeGraphEdge.create: given valid input, it should return an ok edge", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphEdge.create(validInput);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("KnowledgeGraphEdge.create: given valid input, it should stamp now as the created-at metadata", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphEdge.create(validInput);
+
+  // THEN
+  expect(result.ok && result.value.metadata.createdAt).toEqual(now);
+});
+
+test("KnowledgeGraphEdge.create: given fromId equal to toId, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN
+  const nodeId = NodeId.create();
+
+  // WHEN
+  const result = KnowledgeGraphEdge.create({
+    ...validInput,
+    fromId: nodeId,
+    toId: nodeId,
+  });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+  expect(result.error.category).toBe("validation");
+});
+
+test("KnowledgeGraphEdge.create: given confidence above 1, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphEdge.create({ ...validInput, confidence: 1.5 });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+});
+
+test("KnowledgeGraphEdge.create: given confidence below 0, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphEdge.create({ ...validInput, confidence: -0.1 });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+});
+
+test("KnowledgeGraphEdge.create: given no source events, it should return an InvalidKnowledgeGraphEdge error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphEdge.create({
+    ...validInput,
+    sourceEventIds: [],
+  });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphEdge");
+});
+
+const storedRow = {
+  id: "01952d3f-0000-7000-8000-000000000010",
+  graphId: "01952d3f-0000-7000-8000-000000000011",
+  fromId: "01952d3f-0000-7000-8000-000000000012",
+  toId: "01952d3f-0000-7000-8000-000000000013",
+  relationship: "MENTIONS" as const,
+  confidence: 0.9,
+  sourceEventIds: ["01952d3f-0000-7000-8000-000000000014"],
+  observedAt,
+  createdAt: now,
+  updatedAt: new Date("2026-01-03T00:00:00Z"),
+};
+
+test("KnowledgeGraphEdge.restore: given a stored row, it should preserve the id and audit timestamps", () => {
+  // GIVEN / WHEN
+  const edge = KnowledgeGraphEdge.restore(storedRow);
+
+  // THEN
+  expect(edge.id.value).toBe(storedRow.id);
+  expect(edge.metadata.createdAt).toEqual(storedRow.createdAt);
+  expect(edge.metadata.updatedAt).toEqual(storedRow.updatedAt);
+});
+
+test("KnowledgeGraphEdge.restore: given a row with out-of-range confidence, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() =>
+    KnowledgeGraphEdge.restore({ ...storedRow, confidence: 2 }),
+  ).toThrow();
+});

--- a/packages/server-knowledge/src/domain/knowledge-graph-node.aggregate.test.ts
+++ b/packages/server-knowledge/src/domain/knowledge-graph-node.aggregate.test.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "bun:test";
+
+import { EventId } from "./event-id.value-object.ts";
+import { KnowledgeGraphId } from "./knowledge-graph-id.value-object.ts";
+import { KnowledgeGraphNode } from "./knowledge-graph-node.aggregate.ts";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+const validInput = {
+  graphId: KnowledgeGraphId.create(),
+  type: "PERSON" as const,
+  body: "Ada Lovelace",
+  eventIds: [EventId.create()],
+  now,
+};
+
+test("KnowledgeGraphNode.create: given valid input, it should return an ok node", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphNode.create(validInput);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("KnowledgeGraphNode.create: given valid input, it should stamp now as the created-at metadata", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphNode.create(validInput);
+
+  // THEN
+  expect(result.ok && result.value.metadata.createdAt).toEqual(now);
+});
+
+test("KnowledgeGraphNode.create: given a fresh node, it should mint a distinct id each time", () => {
+  // GIVEN / WHEN
+  const a = KnowledgeGraphNode.create(validInput);
+  const b = KnowledgeGraphNode.create(validInput);
+
+  // THEN
+  expect(a.ok && b.ok && a.value.id.value).not.toBe(
+    b.ok ? b.value.id.value : "",
+  );
+});
+
+test("KnowledgeGraphNode.create: given a blank body, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphNode.create({ ...validInput, body: "   " });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+  expect(result.error.category).toBe("validation");
+});
+
+test("KnowledgeGraphNode.create: given no source events, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraphNode.create({ ...validInput, eventIds: [] });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+});
+
+test("KnowledgeGraphNode.create: given only duplicate source events, it should still be allowed", () => {
+  // GIVEN
+  const eventId = EventId.create();
+
+  // WHEN
+  const result = KnowledgeGraphNode.create({
+    ...validInput,
+    eventIds: [eventId, eventId],
+  });
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+const storedRow = {
+  id: "01952d3f-0000-7000-8000-000000000001",
+  graphId: "01952d3f-0000-7000-8000-000000000002",
+  type: "PERSON" as const,
+  body: "Ada Lovelace",
+  eventIds: ["01952d3f-0000-7000-8000-000000000003"],
+  embedding: null,
+  createdAt: now,
+  updatedAt: new Date("2026-01-03T00:00:00Z"),
+};
+
+test("KnowledgeGraphNode.restore: given a stored row, it should preserve the id and audit timestamps", () => {
+  // GIVEN / WHEN
+  const node = KnowledgeGraphNode.restore(storedRow);
+
+  // THEN
+  expect(node.id.value).toBe(storedRow.id);
+  expect(node.metadata.createdAt).toEqual(storedRow.createdAt);
+  expect(node.metadata.updatedAt).toEqual(storedRow.updatedAt);
+});
+
+test("KnowledgeGraphNode.restore: given a row with no source events, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() =>
+    KnowledgeGraphNode.restore({ ...storedRow, eventIds: [] }),
+  ).toThrow();
+});

--- a/packages/server-knowledge/src/domain/knowledge-graph.aggregate.test.ts
+++ b/packages/server-knowledge/src/domain/knowledge-graph.aggregate.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+
+import { KnowledgeGraph } from "./knowledge-graph.aggregate.ts";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+const validInput = {
+  name: "people",
+  embeddingModel: "text-embedding-3-small",
+  embeddingDimensions: 1536,
+  now,
+};
+
+test("KnowledgeGraph.create: given valid input, it should return an ok KnowledgeGraph", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create(validInput);
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("KnowledgeGraph.create: given valid input, it should stamp now as both created-at and updated-at metadata", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create(validInput);
+
+  // THEN
+  expect(result.ok && result.value.metadata.createdAt).toEqual(now);
+  expect(result.ok && result.value.metadata.updatedAt).toEqual(now);
+});
+
+test("KnowledgeGraph.create: given a fresh graph, it should mint a distinct id each time", () => {
+  // GIVEN / WHEN
+  const a = KnowledgeGraph.create(validInput);
+  const b = KnowledgeGraph.create(validInput);
+
+  // THEN
+  expect(a.ok && b.ok && a.value.id.value).not.toBe(
+    b.ok ? b.value.id.value : "",
+  );
+});
+
+test("KnowledgeGraph.create: given a blank name, it should return an InvalidKnowledgeGraph error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create({ ...validInput, name: "   " });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraph");
+  expect(result.error.category).toBe("validation");
+});
+
+test("KnowledgeGraph.create: given a blank embedding model, it should return an InvalidKnowledgeGraph error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create({ ...validInput, embeddingModel: "" });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraph");
+});
+
+test("KnowledgeGraph.create: given non-positive embedding dimensions, it should return an InvalidKnowledgeGraph error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create({
+    ...validInput,
+    embeddingDimensions: 0,
+  });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraph");
+});
+
+test("KnowledgeGraph.create: given non-integer embedding dimensions, it should return an InvalidKnowledgeGraph error", () => {
+  // GIVEN / WHEN
+  const result = KnowledgeGraph.create({
+    ...validInput,
+    embeddingDimensions: 1.5,
+  });
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraph");
+});
+
+const storedRow = {
+  id: "01952d3f-0000-7000-8000-000000000000",
+  name: "people",
+  embeddingModel: "text-embedding-3-small",
+  embeddingDimensions: 1536,
+  createdAt: now,
+  updatedAt: new Date("2026-01-03T00:00:00Z"),
+};
+
+test("KnowledgeGraph.restore: given a stored row, it should preserve the id and audit timestamps", () => {
+  // GIVEN / WHEN
+  const graph = KnowledgeGraph.restore(storedRow);
+
+  // THEN
+  expect(graph.id.value).toBe(storedRow.id);
+  expect(graph.metadata.createdAt).toEqual(storedRow.createdAt);
+  expect(graph.metadata.updatedAt).toEqual(storedRow.updatedAt);
+});
+
+test("KnowledgeGraph.restore: given a row with a blank name, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() => KnowledgeGraph.restore({ ...storedRow, name: "  " })).toThrow();
+});

--- a/packages/server-knowledge/src/domain/node-body.value-object.test.ts
+++ b/packages/server-knowledge/src/domain/node-body.value-object.test.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "bun:test";
+
+import { NodeBody } from "./node-body.value-object.ts";
+
+const MAX_NODE_BODY_LENGTH = 10_000;
+
+test("NodeBody.create: given non-empty text, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = NodeBody.create("Ada Lovelace");
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("NodeBody.create: given empty text, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = NodeBody.create("");
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+  expect(result.error.category).toBe("validation");
+});
+
+test("NodeBody.create: given whitespace-only text, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = NodeBody.create("   ");
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+});
+
+test("NodeBody.create: given text at the maximum length, it should return ok", () => {
+  // GIVEN / WHEN
+  const result = NodeBody.create("a".repeat(MAX_NODE_BODY_LENGTH));
+
+  // THEN
+  expect(result.ok).toBe(true);
+});
+
+test("NodeBody.create: given text longer than the maximum, it should return an InvalidKnowledgeGraphNode error", () => {
+  // GIVEN / WHEN
+  const result = NodeBody.create("a".repeat(MAX_NODE_BODY_LENGTH + 1));
+
+  // THEN
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error.kind).toBe("InvalidKnowledgeGraphNode");
+});
+
+test("NodeBody.create: given surrounding whitespace, it should trim before storing", () => {
+  // GIVEN
+  const created = NodeBody.create("  hello  ");
+  if (!created.ok) throw new Error("expected ok");
+
+  // WHEN / THEN
+  expect(created.value.equals(NodeBody.restore("hello"))).toBe(true);
+});
+
+test("NodeBody.restore: given empty text, it should throw", () => {
+  // GIVEN / WHEN / THEN
+  expect(() => NodeBody.restore("")).toThrow();
+});


### PR DESCRIPTION
Add unit tests for the knowledge bounded context's aggregates and value
objects, exercising the invariants enforced on create/restore: name and
embedding-model presence, positive integer embedding dimensions, node body
bounds, at-least-one source event, confidence range, the no-self-loop edge
rule, and embedding dimension derivation.

https://claude.ai/code/session_01KS8b1u8WT2ACvYXXPnT94J