### PR TITLE
feat(server-ingestion): add capture event inbound port

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: git-commit
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+license: MIT
+---
+
+# Git Commit with Conventional Commits
+
+## Overview
+
+Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+
+## Conventional Commit Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Purpose                        |
+| ---------- | ------------------------------ |
+| `feat`     | New feature                    |
+| `fix`      | Bug fix                        |
+| `docs`     | Documentation only             |
+| `style`    | Formatting/style (no logic)    |
+| `refactor` | Code refactor (no feature/fix) |
+| `perf`     | Performance improvement        |
+| `test`     | Add/update tests               |
+| `build`    | Build system/dependencies      |
+| `ci`       | CI/config changes              |
+| `chore`    | Maintenance/misc               |
+| `revert`   | Revert commit                  |
+
+## Breaking Changes
+
+```
+# Exclamation mark after type/scope
+feat!: remove deprecated endpoint
+
+# BREAKING CHANGE footer
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
+## Workflow
+
+### 1. Analyze Diff
+
+```bash
+# If files are staged, use staged diff
+git diff --staged
+
+# If nothing staged, use working tree diff
+git diff
+
+# Also check status
+git status --porcelain
+```
+
+### 2. Stage Files (if needed)
+
+If nothing is staged or you want to group changes differently:
+
+```bash
+# Stage specific files
+git add path/to/file1 path/to/file2
+
+# Stage by pattern
+git add *.test.*
+git add src/components/*
+
+# Interactive staging
+git add -p
+```
+
+**Never commit secrets** (.env, credentials.json, private keys).
+
+### 3. Generate Commit Message
+
+Analyze the diff to determine:
+
+- **Type**: What kind of change is this?
+- **Scope**: What area/module is affected?
+- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
+
+### 4. Execute Commit
+
+```bash
+# Single line
+git commit -m "<type>[scope]: <description>"
+
+# Multi-line with body/footer
+git commit -m "$(cat <<'EOF'
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+EOF
+)"
+```
+
+## Best Practices
+
+- One logical change per commit
+- Present tense: "add" not "added"
+- Imperative mood: "fix bug" not "fixes bug"
+- Reference issues: `Closes #123`, `Refs #456`
+- Keep description under 72 characters
+
+## Git Safety Protocol
+
+- NEVER update git config
+- NEVER run destructive commands (--force, hard reset) without explicit request
+- NEVER skip hooks (--no-verify) unless user asks
+- NEVER force push to main/master
+- If commit fails due to hooks, fix and create NEW commit (don't amend)

--- a/packages/server-ingestion/src/application/ports/inbound/capture-event.use-case.ts
+++ b/packages/server-ingestion/src/application/ports/inbound/capture-event.use-case.ts
@@ -1,0 +1,21 @@
+import type { Result } from "@repo/server-kernel";
+
+/** `recordedAt` is omitted: the use case stamps it from a Clock, not the caller. */
+export type CaptureEventUseCaseInput = {
+  occurredAt: Date;
+  tags: Record<string, string>;
+  body: Record<string, unknown>;
+};
+
+/** Id only — the aggregate must not cross the inbound boundary. */
+export type CaptureEventUseCaseOutput = {
+  eventId: string;
+};
+
+/** Returns `Result` because failure (e.g. `InvalidEvent`) is expected; true
+ *  faults throw and are mapped to a response at the adapter. */
+export interface CaptureEventUseCase {
+  execute(
+    input: CaptureEventUseCaseInput,
+  ): Promise<Result<CaptureEventUseCaseOutput>>;
+}

--- a/packages/server-ingestion/src/index.ts
+++ b/packages/server-ingestion/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./application/ports/inbound/capture-event.use-case.ts";
+
 export * from "./domain/event.aggregate.ts";
 export * from "./domain/event-body.value-object.ts";
 export * from "./domain/event-id.value-object.ts";


### PR DESCRIPTION
Define the CaptureEventUseCase driving port (interface + input/output types) for the ingestion context's application layer. recordedAt is omitted from the input — the use case stamps it from a Clock — and the output carries only the new event id so the aggregate never crosses the inbound boundary.