### PR TITLE
feat(server-ingestion): add event log port, rename capture to ingest

### DIFF
--- a/packages/server-ingestion/src/application/ports/inbound/ingest-event.use-case.ts
+++ b/packages/server-ingestion/src/application/ports/inbound/ingest-event.use-case.ts
@@ -1,21 +1,21 @@
 import type { Result } from "@repo/server-kernel";
 
 /** `recordedAt` is omitted: the use case stamps it from a Clock, not the caller. */
-export type CaptureEventUseCaseInput = {
+export type IngestEventUseCaseInput = {
   occurredAt: Date;
   tags: Record<string, string>;
   body: Record<string, unknown>;
 };
 
 /** Id only — the aggregate must not cross the inbound boundary. */
-export type CaptureEventUseCaseOutput = {
+export type IngestEventUseCaseOutput = {
   eventId: string;
 };
 
 /** Returns `Result` because failure (e.g. `InvalidEvent`) is expected; true
  *  faults throw and are mapped to a response at the adapter. */
-export interface CaptureEventUseCase {
+export interface IngestEventUseCase {
   execute(
-    input: CaptureEventUseCaseInput,
-  ): Promise<Result<CaptureEventUseCaseOutput>>;
+    input: IngestEventUseCaseInput,
+  ): Promise<Result<IngestEventUseCaseOutput>>;
 }

--- a/packages/server-ingestion/src/application/ports/outbound/event-log.repository.ts
+++ b/packages/server-ingestion/src/application/ports/outbound/event-log.repository.ts
@@ -1,0 +1,7 @@
+import type { Event } from "../../../domain/event.aggregate.ts";
+
+/** `append`, not `save`: events are immutable facts — the log only grows,
+ *  never updates or deletes. */
+export interface EventLogRepository {
+  append(event: Event): Promise<void>;
+}

--- a/packages/server-ingestion/src/index.ts
+++ b/packages/server-ingestion/src/index.ts
@@ -1,4 +1,5 @@
-export * from "./application/ports/inbound/capture-event.use-case.ts";
+export * from "./application/ports/inbound/ingest-event.use-case.ts";
+export * from "./application/ports/outbound/event-log.repository.ts";
 
 export * from "./domain/event.aggregate.ts";
 export * from "./domain/event-body.value-object.ts";


### PR DESCRIPTION
Rename the inbound CaptureEvent use case to IngestEvent (keeping the Result return), and add the EventLogRepository outbound port — the append-only persistence seam the use case will depend on.