### PR TITLE
Refactor knowledge graph processing docs into modular sub-docs

### DIFF
--- a/docs/thoughts/feature-knowledge-graph-processing-event-consumption.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-event-consumption.md
@@ -6,37 +6,28 @@ Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-gr
 
 ## 1. How this context consumes events
 
-Enrichment must be _triggered_ and must _know which events are new_. When this design was first drafted, the upstream publisher did not exist, so the only buildable option was a cron batch-pull with a cursor. **That has changed.** Ingestion now publishes recorded events through a transactional outbox into Amazon SQS ([`feature-event-publication.md`](./feature-event-publication.md); ADR [`20260524-outbox-sqs-event-publication`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)), and the worker trigger model is settled (ADR [`20260529-in-process-sleep-jitter-worker-trigger`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md)).
+Enrichment must be _triggered_ and must _know which events to process_. When this design was first drafted the upstream publisher did not exist, so the only buildable option was a cron batch-pull with a cursor. **That has changed.** Ingestion now publishes recorded events through a transactional outbox into Amazon SQS ([`feature-event-publication.md`](./feature-event-publication.md); ADR [`20260524-outbox-sqs-event-publication`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)), so enrichment is driven entirely off that queue.
 
-So the two shapes that were once "buildable today vs blocked on a future seam" are now **both available**, and we use them together:
+**Decision: SQS push is the only trigger.** One recorded event → one thin SQS message `{ eventId, occurredAt, recordedAt, tags }` → `EnrichEvents.execute({ eventIds })`. There is **no cursor/reconcile path**:
 
-|                             | SQS push (hot path)                                                                 | Cursor reconcile (safety net)                                                       |
-| --------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **What drives it**          | A thin SQS message `{ eventId, occurredAt, recordedAt, tags }` per recorded event. | A jittered catch-up loop reading `WHERE recordedAt > cursor ORDER BY recordedAt, id`. |
-| **Latency**                 | Seconds (relay cadence + push).                                                     | Minutes (reconcile interval).                                                       |
-| **Body**                    | Re-read locally by `eventId` (the message is thin — §2).                            | Read in the page query.                                                             |
-| **Role**                    | Primary — most events flow through here.                                            | Backstop — catches anything SQS dropped, a relay gap, or a poison-message replay.  |
-| **Idempotency**             | `ProcessedEventLedger` (idempotency sub-doc).                                       | Same ledger — a reconciled event already pushed is a no-op.                         |
+- **The message is thin**, so the consumer re-reads the body by id (`EventSourceReader.findByIds`) before extracting (§2).
+- **The consumer runs in `apps/server-knowledge-worker`** as a long-poll loop over SQS. Correctness comes from the **resource, not the tick**: SQS visibility-timeout + competing-consumer semantics give one in-flight delivery at a time, and the `ProcessedEventLedger`'s `eventId` idempotency (idempotency sub-doc) absorbs at-least-once redelivery.
+- **Poison messages** that fail repeatedly land in the SQS **DLQ** (`feature-event-publication.md` §7) for inspection — they never block the stream.
 
-**Decision: SQS push as the hot path, cursor reconcile as the safety net — both driving the same use-case core.** This is exactly the graduation the first draft anticipated ("when ingestion grows the publisher seam, a queue-driving adapter becomes a new driving adapter over the same use case; the cursor degrades to a safety-net reconciler"). It is now realized rather than deferred:
-
-- **Triggering is a sleep + jitter loop, not cron** (ADR `20260529`). The enricher (`apps/server-knowledge-worker`) is a long-running container that polls SQS on a short jittered interval and runs the reconcile pull on a longer one. Correctness comes from the **resource**, not the tick: SQS visibility-timeout + competing-consumer semantics for the push path, `SELECT … FOR UPDATE SKIP LOCKED` (or an advisory lock) over the page for the reconcile path, and the ledger's `eventId` idempotency covering at-least-once redelivery on both.
-- **The inbound ports are agnostic to _who_ calls them** (§4). The SQS consumer maps a message batch to `EnrichEvents.execute({ eventIds })`; the reconcile loop calls `ReconcileEnrichment.execute({ batchSize })`. Both funnel into one internal enrichment routine (§5).
-
-> **Why keep the cursor at all now that push exists?** SQS is at-least-once but not at-_least_-once-_forever_: a message can be dropped past its DLQ, a relay can fall behind, a deploy can race. The `events` table is the source of truth (`feature-event-publication.md` §2), and a cheap periodic `WHERE recordedAt > cursor` sweep guarantees **eventual completeness** independent of broker health. It is the same reconciler the ADR calls "a scheduled catch-up/reconcile poll [that] backs it up."
+> **What about completeness without a reconcile poll?** Delivery guarantees rest on SQS at-least-once, the relay's own at-least-once publish (`feature-event-publication.md` §7), and the DLQ. The `events` table remains the source of truth (`feature-event-publication.md` §2), so if a gap is ever discovered, re-enqueuing from it is a manual/operational backfill — not a standing cursor loop. A scheduled reconciler can be added later behind a **new driving adapter over the same `EnrichEvents` core** if evidence demands it; it is deliberately out of scope now.
 
 ---
 
 ## 2. Cross-context integration (context mapping)
 
-Both drivers ultimately need the event's **`body`** (and `tags`, `occurredAt`) to extract anything — and that data belongs to the **ingestion** bounded context. The SQS message is deliberately **thin** (`feature-event-publication.md` §3: body omitted because it is opaque, can exceed SQS's 256 KB cap, and would go stale), so the body is **re-read** from the source of truth. Three integration styles (DDD context-mapping terms in parentheses):
+The consumer ultimately needs the event's **`body`** (and `tags`, `occurredAt`) to extract anything — and that data belongs to the **ingestion** bounded context. The SQS message is deliberately **thin** (`feature-event-publication.md` §3: body omitted because it is opaque, can exceed SQS's 256 KB cap, and would go stale), so the body is **re-read** from the source of truth. Three integration styles (DDD context-mapping terms in parentheses):
 
 |                     | Shared-DB read via ACL port _(Shared Database)_                                                                              | Payload-in-event _(Published Language)_                                          | Sync read API _(Open-Host / Customer-Supplier)_                 |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | **How**             | A `server-knowledge-infra` adapter `SELECT`s the `events` table directly, behind our `EventSourceReader` port, mapping rows → our DTO. | The message carries the full `{occurredAt, tags, body}`; we consume the payload off the queue. | We call an ingestion HTTP/RPC endpoint to fetch event payloads. |
 | **Buildable now**   | **Yes** (one consolidated Aurora cluster — ADR `20260523-consolidated-aurora-postgresql`).                                  | No — the published event is thin by deliberate design (§1, `feature-event-publication.md` §3). | No (no such endpoint; both runtimes already share the DB).      |
 | **Coupling**        | **Highest** — two contexts share a table. Mitigated by the ACL (below).                                                     | Low — contexts share only a message contract.                                   | Low — contexts share only an API contract.                     |
-| **Latency / cost**  | One local query per event/page.                                                                                             | None extra, but fat messages risk the 256 KB cap and staleness.                 | Network hop + ingestion serving load.                          |
+| **Latency / cost**  | One local query per event.                                                                                                 | None extra, but fat messages risk the 256 KB cap and staleness.                 | Network hop + ingestion serving load.                          |
 | **Fit for Phase 0** | **Best** — pragmatic on a consolidated DB.                                                                                  | Rejected upstream (thin events).                                                | Pointless indirection (same DB, two of our own runtimes).      |
 
 **Decision: shared-DB read behind an anti-corruption `EventSourceReader` port.** Name the coupling honestly — it _is_ the most-coupled option — and contain it:
@@ -60,28 +51,16 @@ export interface EventEntry {
   body: Record<string, unknown>;
 }
 export interface EventSourceReader {
-  findByIds(ids: EventId[]): Promise<EventEntry[]>; // SQS push: re-read bodies for a message batch
-  readSince(cursor: Checkpoint, limit: number): Promise<EventEntry[]>; // reconcile: ORDER BY recordedAt, id
-}
-
-// checkpoint.store.ts — progress (the reconcile cursor)
-export interface Checkpoint {
-  recordedAt: Date;
-  lastEventId: EventId;
-}
-export interface CheckpointStore {
-  load(name: string): Promise<Checkpoint>;
-  save(name: string, cursor: Checkpoint): Promise<void>;
+  findByIds(ids: EventId[]): Promise<EventEntry[]>; // re-read bodies for the ids named in an SQS batch
 }
 ```
 
-`findByIds` serves the push path (re-read bodies for the ids named in an SQS batch); `readSince` serves the reconcile path. Both map raw `events` rows to the KG-owned `EventEntry`.
+`findByIds` maps raw `events` rows to the KG-owned `EventEntry` for the ids named in an SQS message batch. (There is no `readSince`/cursor — the reconcile path was dropped, §1.)
 
 ## 4. Inbound (driving) ports
 
 ```ts
 export interface EnrichmentReport {
-  pulled: number;
   processed: number;
   skipped: number;
   failed: number;
@@ -89,36 +68,23 @@ export interface EnrichmentReport {
   edgesWritten: number;
 }
 
-// enrich-events.use-case.ts — driven by the SQS consumer (hot path)
+// enrich-events.use-case.ts — driven by the SQS consumer
 export interface EnrichEvents {
   execute(input: { eventIds: EventId[] }): Promise<Result<EnrichmentReport>>;
 }
-
-// reconcile-enrichment.use-case.ts — driven by the jittered catch-up loop (safety net)
-export interface ReconcileEnrichment {
-  execute(input: { batchSize: number }): Promise<Result<EnrichmentReport & { cursor: Checkpoint }>>;
-}
 ```
 
-Both are **agnostic to their driver**: a queue consumer, a cron, a manual backfill, or a test can call either. `EmbedNodes` and `MergeDuplicateNodes` (resolution sub-doc) are separate inbound ports on their own jittered loops.
+`EnrichEvents` is **agnostic to its driver**: the SQS consumer drives it today, but a manual backfill or a test can call it with any set of ids. `EmbedNodes` and `MergeDuplicateNodes` (resolution sub-doc) are separate inbound ports on their own jittered loops.
 
 ---
 
 ## 5. Enrichment orchestration (shared by both drivers)
 
-Both use cases funnel into one internal routine over a set of `EventEntry`. Cross-cutting concerns it relies on — the ledger guard, `graphId` resolution, the transaction boundary, ordering by `occurredAt` — are detailed in the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md); extraction in the [extraction sub-doc](./feature-knowledge-graph-processing-extraction.md); resolution in the [resolution sub-doc](./feature-knowledge-graph-processing-resolution.md).
+`EnrichEvents` runs one routine over the `EventEntry` set named by an SQS batch. Cross-cutting concerns it relies on — the ledger guard, `graphId` resolution, the transaction boundary, ordering by `occurredAt` — are detailed in the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md); extraction in the [extraction sub-doc](./feature-knowledge-graph-processing-extraction.md); resolution in the [resolution sub-doc](./feature-knowledge-graph-processing-resolution.md).
 
 ```
 EnrichEvents.execute({ eventIds }):
   entries ← EventSourceReader.findByIds(eventIds)
-  enrichEntries(entries)
-
-ReconcileEnrichment.execute({ batchSize }):
-  cursor  ← CheckpointStore.load(name)
-  entries ← EventSourceReader.readSince(cursor, batchSize)   // ORDER BY recordedAt, id
-  enrichEntries(entries, advanceCursorTo: last(entries))
-
-enrichEntries(entries, advanceCursorTo?):
   drop entries already in ProcessedEventLedger (current extractorVersion)
   sort entries by occurredAt                                  // for correct edge.observedAt
   for each entry:
@@ -133,7 +99,7 @@ enrichEntries(entries, advanceCursorTo?):
     for each candidate edge:
        load from/to nodes; existing ← edgeRepo.findByTriple(...)
        edge ← GraphRelation.relate({ …, observedAt: entry.occurredAt, existing, now })   // create or reinforce
-  in ONE UnitOfWork: nodeRepo.saveMany + edgeRepo.saveMany + ledger.record(...) + (if advanceCursorTo) CheckpointStore.save
+  in ONE UnitOfWork: nodeRepo.saveMany + edgeRepo.saveMany + ledger.record(...)
 ```
 
 > **Note — the domain factories mint ids.** `KnowledgeGraphNode.create` / `KnowledgeGraphEdge.create` take only `{ …, now }` and mint `NodeId`/`EdgeId` internally (kernel UUID v7). There is no `IdGenerator` port; the app supplies `now` from the `Clock`.

--- a/docs/thoughts/feature-knowledge-graph-processing-event-consumption.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-event-consumption.md
@@ -1,0 +1,142 @@
+# Knowledge Graph Processing — Event Consumption & Cross-Context Integration
+
+Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-graph-processing.md). Covers **how enrichment is triggered** and **how it reads events that belong to the ingestion context**. Sibling sub-docs: [extraction](./feature-knowledge-graph-processing-extraction.md), [resolution & embedding](./feature-knowledge-graph-processing-resolution.md), [idempotency & consistency](./feature-knowledge-graph-processing-idempotency.md).
+
+---
+
+## 1. How this context consumes events
+
+Enrichment must be _triggered_ and must _know which events are new_. When this design was first drafted, the upstream publisher did not exist, so the only buildable option was a cron batch-pull with a cursor. **That has changed.** Ingestion now publishes recorded events through a transactional outbox into Amazon SQS ([`feature-event-publication.md`](./feature-event-publication.md); ADR [`20260524-outbox-sqs-event-publication`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)), and the worker trigger model is settled (ADR [`20260529-in-process-sleep-jitter-worker-trigger`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md)).
+
+So the two shapes that were once "buildable today vs blocked on a future seam" are now **both available**, and we use them together:
+
+|                             | SQS push (hot path)                                                                 | Cursor reconcile (safety net)                                                       |
+| --------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **What drives it**          | A thin SQS message `{ eventId, occurredAt, recordedAt, tags }` per recorded event. | A jittered catch-up loop reading `WHERE recordedAt > cursor ORDER BY recordedAt, id`. |
+| **Latency**                 | Seconds (relay cadence + push).                                                     | Minutes (reconcile interval).                                                       |
+| **Body**                    | Re-read locally by `eventId` (the message is thin — §2).                            | Read in the page query.                                                             |
+| **Role**                    | Primary — most events flow through here.                                            | Backstop — catches anything SQS dropped, a relay gap, or a poison-message replay.  |
+| **Idempotency**             | `ProcessedEventLedger` (idempotency sub-doc).                                       | Same ledger — a reconciled event already pushed is a no-op.                         |
+
+**Decision: SQS push as the hot path, cursor reconcile as the safety net — both driving the same use-case core.** This is exactly the graduation the first draft anticipated ("when ingestion grows the publisher seam, a queue-driving adapter becomes a new driving adapter over the same use case; the cursor degrades to a safety-net reconciler"). It is now realized rather than deferred:
+
+- **Triggering is a sleep + jitter loop, not cron** (ADR `20260529`). The enricher (`apps/server-knowledge-worker`) is a long-running container that polls SQS on a short jittered interval and runs the reconcile pull on a longer one. Correctness comes from the **resource**, not the tick: SQS visibility-timeout + competing-consumer semantics for the push path, `SELECT … FOR UPDATE SKIP LOCKED` (or an advisory lock) over the page for the reconcile path, and the ledger's `eventId` idempotency covering at-least-once redelivery on both.
+- **The inbound ports are agnostic to _who_ calls them** (§4). The SQS consumer maps a message batch to `EnrichEvents.execute({ eventIds })`; the reconcile loop calls `ReconcileEnrichment.execute({ batchSize })`. Both funnel into one internal enrichment routine (§5).
+
+> **Why keep the cursor at all now that push exists?** SQS is at-least-once but not at-_least_-once-_forever_: a message can be dropped past its DLQ, a relay can fall behind, a deploy can race. The `events` table is the source of truth (`feature-event-publication.md` §2), and a cheap periodic `WHERE recordedAt > cursor` sweep guarantees **eventual completeness** independent of broker health. It is the same reconciler the ADR calls "a scheduled catch-up/reconcile poll [that] backs it up."
+
+---
+
+## 2. Cross-context integration (context mapping)
+
+Both drivers ultimately need the event's **`body`** (and `tags`, `occurredAt`) to extract anything — and that data belongs to the **ingestion** bounded context. The SQS message is deliberately **thin** (`feature-event-publication.md` §3: body omitted because it is opaque, can exceed SQS's 256 KB cap, and would go stale), so the body is **re-read** from the source of truth. Three integration styles (DDD context-mapping terms in parentheses):
+
+|                     | Shared-DB read via ACL port _(Shared Database)_                                                                              | Payload-in-event _(Published Language)_                                          | Sync read API _(Open-Host / Customer-Supplier)_                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **How**             | A `server-knowledge-infra` adapter `SELECT`s the `events` table directly, behind our `EventSourceReader` port, mapping rows → our DTO. | The message carries the full `{occurredAt, tags, body}`; we consume the payload off the queue. | We call an ingestion HTTP/RPC endpoint to fetch event payloads. |
+| **Buildable now**   | **Yes** (one consolidated Aurora cluster — ADR `20260523-consolidated-aurora-postgresql`).                                  | No — the published event is thin by deliberate design (§1, `feature-event-publication.md` §3). | No (no such endpoint; both runtimes already share the DB).      |
+| **Coupling**        | **Highest** — two contexts share a table. Mitigated by the ACL (below).                                                     | Low — contexts share only a message contract.                                   | Low — contexts share only an API contract.                     |
+| **Latency / cost**  | One local query per event/page.                                                                                             | None extra, but fat messages risk the 256 KB cap and staleness.                 | Network hop + ingestion serving load.                          |
+| **Fit for Phase 0** | **Best** — pragmatic on a consolidated DB.                                                                                  | Rejected upstream (thin events).                                                | Pointless indirection (same DB, two of our own runtimes).      |
+
+**Decision: shared-DB read behind an anti-corruption `EventSourceReader` port.** Name the coupling honestly — it _is_ the most-coupled option — and contain it:
+
+1. The adapter returns a **knowledge-owned DTO** (`EventEntry`, §3), **never** the ingestion `Event` aggregate. `@repo/server-knowledge` does not depend on `@repo/server-ingestion`.
+2. Treat the columns we read — `{ id, occurredAt, tags, body }` — as a **published-language read contract**. As long as ingestion preserves those, our adapter is stable.
+
+Because the contract is the port, graduating to payload-in-event (if fat events ever become worthwhile) or to a read API is a **new adapter for the same port** — zero app-layer change. This is the "keep it behind an interface, graduate by evidence" discipline of `database-tradeoffs.md` and `project-structure.md`.
+
+---
+
+## 3. Outbound ports
+
+```ts
+// event-source.reader.ts — anti-corruption read into the ingestion log
+export interface EventEntry {
+  // KG-owned DTO, NOT ingestion's Event aggregate
+  id: EventId;
+  occurredAt: Date;
+  tags: Record<string, string>;
+  body: Record<string, unknown>;
+}
+export interface EventSourceReader {
+  findByIds(ids: EventId[]): Promise<EventEntry[]>; // SQS push: re-read bodies for a message batch
+  readSince(cursor: Checkpoint, limit: number): Promise<EventEntry[]>; // reconcile: ORDER BY recordedAt, id
+}
+
+// checkpoint.store.ts — progress (the reconcile cursor)
+export interface Checkpoint {
+  recordedAt: Date;
+  lastEventId: EventId;
+}
+export interface CheckpointStore {
+  load(name: string): Promise<Checkpoint>;
+  save(name: string, cursor: Checkpoint): Promise<void>;
+}
+```
+
+`findByIds` serves the push path (re-read bodies for the ids named in an SQS batch); `readSince` serves the reconcile path. Both map raw `events` rows to the KG-owned `EventEntry`.
+
+## 4. Inbound (driving) ports
+
+```ts
+export interface EnrichmentReport {
+  pulled: number;
+  processed: number;
+  skipped: number;
+  failed: number;
+  nodesUpserted: number;
+  edgesWritten: number;
+}
+
+// enrich-events.use-case.ts — driven by the SQS consumer (hot path)
+export interface EnrichEvents {
+  execute(input: { eventIds: EventId[] }): Promise<Result<EnrichmentReport>>;
+}
+
+// reconcile-enrichment.use-case.ts — driven by the jittered catch-up loop (safety net)
+export interface ReconcileEnrichment {
+  execute(input: { batchSize: number }): Promise<Result<EnrichmentReport & { cursor: Checkpoint }>>;
+}
+```
+
+Both are **agnostic to their driver**: a queue consumer, a cron, a manual backfill, or a test can call either. `EmbedNodes` and `MergeDuplicateNodes` (resolution sub-doc) are separate inbound ports on their own jittered loops.
+
+---
+
+## 5. Enrichment orchestration (shared by both drivers)
+
+Both use cases funnel into one internal routine over a set of `EventEntry`. Cross-cutting concerns it relies on — the ledger guard, `graphId` resolution, the transaction boundary, ordering by `occurredAt` — are detailed in the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md); extraction in the [extraction sub-doc](./feature-knowledge-graph-processing-extraction.md); resolution in the [resolution sub-doc](./feature-knowledge-graph-processing-resolution.md).
+
+```
+EnrichEvents.execute({ eventIds }):
+  entries ← EventSourceReader.findByIds(eventIds)
+  enrichEntries(entries)
+
+ReconcileEnrichment.execute({ batchSize }):
+  cursor  ← CheckpointStore.load(name)
+  entries ← EventSourceReader.readSince(cursor, batchSize)   // ORDER BY recordedAt, id
+  enrichEntries(entries, advanceCursorTo: last(entries))
+
+enrichEntries(entries, advanceCursorTo?):
+  drop entries already in ProcessedEventLedger (current extractorVersion)
+  sort entries by occurredAt                                  // for correct edge.observedAt
+  for each entry:
+    graphId    ← GraphResolution.resolve(entry.tags)
+    extraction ← EntityExtractorGateway.extract(entry)
+    for each candidate node:
+       matches  ← nodeRepo.findByNaturalKey(...) + NodeResolutionIndex.findSimilar(...)
+       decision ← EntityResolution.classify(candidate, matches)     // pure domain service
+       New        → KnowledgeGraphNode.create({ graphId, type, body, eventIds:[entry.id], now })
+       Resolved   → node.attachEvents([entry.id], now)
+       Ambiguous  → create + queue a DUPLICATE_OF for MergeDuplicateNodes
+    for each candidate edge:
+       load from/to nodes; existing ← edgeRepo.findByTriple(...)
+       edge ← GraphRelation.relate({ …, observedAt: entry.occurredAt, existing, now })   // create or reinforce
+  in ONE UnitOfWork: nodeRepo.saveMany + edgeRepo.saveMany + ledger.record(...) + (if advanceCursorTo) CheckpointStore.save
+```
+
+> **Note — the domain factories mint ids.** `KnowledgeGraphNode.create` / `KnowledgeGraphEdge.create` take only `{ …, now }` and mint `NodeId`/`EdgeId` internally (kernel UUID v7). There is no `IdGenerator` port; the app supplies `now` from the `Clock`.
+
+> **Note — node birth is unembedded.** `KnowledgeGraphNode.create` always sets `embedding: null`. Embeddings are assigned later by `EmbedNodes` (resolution sub-doc), so an embedding outage never blocks this routine.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing-extraction.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-extraction.md
@@ -1,0 +1,76 @@
+# Knowledge Graph Processing — Extraction
+
+Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-graph-processing.md). Covers turning an event entry's **opaque body** into **typed candidates**. Sibling sub-docs: [event consumption](./feature-knowledge-graph-processing-event-consumption.md), [resolution & embedding](./feature-knowledge-graph-processing-resolution.md), [idempotency & consistency](./feature-knowledge-graph-processing-idempotency.md).
+
+---
+
+## 1. Opaque body → typed candidates
+
+The extractor turns an event entry's **opaque** body into **candidates** already typed to the closed vocabulary (`NodeType` / `RelationshipType`, from `@repo/server-knowledge`). It is pure I/O (a model/parse call), so it is an **outbound gateway port** (`EntityExtractorGateway`); the use case never embeds extraction logic.
+
+**Decision: hybrid extraction, routed on `tags`.** `tags` is explicitly _"what the Worker routes on"_ (`feature-event-ingestion.md` §2), and it is the part of the published message that arrives even before the body is re-read (event consumption sub-doc §2):
+
+- **Deterministic rules** for known _structured_ sources (a Slack message, a GitHub PR, a calendar invite). Cheap, exact, **deterministic** — and the only reliable source of _structural_ relationships.
+- **LLM structured-output** for _free-text_ bodies, constrained to emit only `NodeType`/`RelationshipType` members.
+
+|                                | Rules (structured sources) | LLM (free-text)        | Hybrid (recommended)                |
+| ------------------------------ | -------------------------- | ---------------------- | ----------------------------------- |
+| **Accuracy on known shapes**   | **High**                   | Medium                 | **High**                            |
+| **Coverage of unknown shapes** | Low                        | **High**               | **High**                            |
+| **Cost / latency**             | **Negligible**             | High                   | Pay LLM cost **only** for free-text |
+| **Determinism / idempotency**  | **Deterministic**          | Non-deterministic      | Deterministic where it matters most |
+
+The non-determinism of the LLM path is what forces the `eventId`-anchored idempotency design — see the [idempotency sub-doc](./feature-knowledge-graph-processing-idempotency.md).
+
+> **Vocabulary is enforced in the gateway adapter, not the orchestrator.** The gateway's _output type_ is already `NodeType`/`RelationshipType`; mapping an un-classifiable relation to `RELATED_TO` (or dropping it) happens **inside the adapter** (e.g. via a structured-output schema/grammar). If the gateway returned free strings and the use case mapped them, vocabulary governance would leak into the application layer. The closed vocabulary is the domain's contract; the adapter honors it.
+
+---
+
+## 2. Where the typed relationships come from
+
+A mapping the doc makes explicit so adapters stay consistent. The `RelationshipType` values below are the ones the domain ships (`relationship-type.value-object.ts`).
+
+| Source signal                       | Candidate relationship               | Notes                                      |
+| ----------------------------------- | ------------------------------------ | ------------------------------------------ |
+| message `author` field              | `AUTHORED_BY` / `SENT_BY`            | Deterministic, from structured metadata.   |
+| thread `parent`/`in_reply_to`       | `REPLIES_TO`                         | Deterministic.                             |
+| document → its section/attachment   | `PART_OF`                            | Deterministic structural composition.      |
+| task `assignee`                     | `ASSIGNED_TO`                        | Deterministic.                             |
+| free-text naming a person/org/topic | `MENTIONS`, `INVOLVES`, `RELATED_TO` | LLM; default to the weakest accurate type. |
+| explicit "see also" / citation      | `REFERENCES`                         | Either, depending on source.               |
+
+> **Do not conflate `DERIVED_FROM` with `eventIds` provenance.** A node's link back to the **events** that justify it is the node's `eventIds` set (`KnowledgeGraphNode`) — **not** an edge. `DERIVED_FROM` is a **node→node** lineage edge (e.g. a summary node derived from a document node). The extractor must keep these separate; emitting `DERIVED_FROM` edges to represent event provenance would double-model the data and corrupt traversal. This is the one hard boundary the domain set, and the application layer honors it.
+
+---
+
+## 3. Outbound port
+
+```ts
+// entity-extractor.gateway.ts — opaque body → candidates already typed to the closed vocab
+export interface CandidateNode {
+  type: NodeType;
+  body: string;
+  naturalKey?: string; // e.g. canonical email/handle — feeds deterministic resolution
+}
+export interface CandidateRef {
+  // how a candidate edge points at a candidate node within one extraction
+  ref: string; // local id within this ExtractionResult
+}
+export interface CandidateEdge {
+  from: CandidateRef;
+  to: CandidateRef;
+  relationship: RelationshipType;
+  confidence: number;
+}
+export interface ExtractionResult {
+  nodes: CandidateNode[];
+  edges: CandidateEdge[];
+  extractorVersion: string; // bumped per logic/prompt/model change — see idempotency sub-doc
+}
+export interface EntityExtractorGateway {
+  extract(entry: EventEntry): Promise<ExtractionResult>; // vocabulary enforced in the adapter
+}
+```
+
+`extractorVersion` is returned by the gateway, not hard-coded in the use case: bumping it makes the processed-events ledger miss and legitimately reprocesses events under the better extractor (idempotency sub-doc). `naturalKey` and `body` are the inputs to node-body canonicalization and resolution (resolution sub-doc) — the same text drives both the embedding and the natural key, so the adapter's canonicalization choices govern over/under-merge.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing-idempotency.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-idempotency.md
@@ -6,7 +6,7 @@ Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-gr
 
 ## 1. Idempotency & delivery semantics
 
-Processing is **at-least-once** by design (`feature-event-publication.md` §2; ADR [`20260524`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)): the relay re-publishes after a crash, SQS redelivers, and the reconcile poll (event consumption sub-doc) can re-see an event the push path already handled. Therefore **writes must be idempotent**.
+Processing is **at-least-once** by design (`feature-event-publication.md` §2; ADR [`20260524`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)): the relay re-publishes after a crash and SQS redelivers, so the same event can reach `EnrichEvents` more than once. Therefore **writes must be idempotent**.
 
 The domain _gives_ us idempotent writes — **but only if resolution is stable**:
 
@@ -15,12 +15,11 @@ The domain _gives_ us idempotent writes — **but only if resolution is stable**
 
 The threat: **LLM extraction is non-deterministic** (extraction sub-doc §1), so the _same_ event reprocessed can yield slightly different candidates, which could resolve to _different_ nodes and break that stability.
 
-**Decision: anchor idempotency on the deterministic `eventId`, not on extractor output. Keep two distinct mechanisms:**
+**Decision: anchor idempotency on the deterministic `eventId`, not on extractor output, via a processed-events ledger:**
 
-| Mechanism                   | Question it answers                          | Key                                                        | Why separate                                                                       |
+| Mechanism                   | Question it answers                          | Key                                                        | Why it works                                                                       |
 | --------------------------- | -------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Checkpoint / cursor**     | "How far have we _pulled_?"                  | `recordedAt` high-water mark                               | Progress only. Append-only log ⇒ monotonic, safe. Backs the SQS push (event consumption sub-doc §1). |
-| **Processed-events ledger** | "Was this event's _effect_ already applied?" | `(eventId, extractorVersion) → status, factHash, attempts` | **Exactly-once effect.** Skip an already-processed event regardless of LLM jitter or which driver delivered it. |
+| **Processed-events ledger** | "Was this event's _effect_ already applied?" | `(eventId, extractorVersion) → status, factHash, attempts` | **Exactly-once effect.** Skip an already-processed event regardless of LLM jitter or how many times SQS delivers it. |
 
 Layered guards beneath the ledger: **deterministic candidate keys** (normalized name+type — resolution sub-doc §1/§3) so even a re-extraction resolves to the _same_ node; and **`factHash`** of `(eventId, normalized-fact)` to skip re-asserting a fact already recorded (avoids confidence churn).
 
@@ -30,10 +29,10 @@ Layered guards beneath the ledger: **deterministic candidate keys** (normalized 
 
 ## 2. Cross-cutting consistency & failure
 
-- **Transaction boundary.** Per Approach A of the domain, node and edge are separate aggregates. A run wraps its writes — **nodes + edges + ledger rows + (reconcile only) checkpoint** — in a **context-owned unit-of-work** (§4), so a page commits atomically while we are still on one Aurora Postgres (ADR [`20260523-consolidated-aurora-postgresql`](../../decision-records/server/20260523-consolidated-aurora-postgresql.md)). When the graph store later splits out (e.g. Neptune), this degrades to _accepted eventual consistency_ (domain §8) — the "no dangling edge / no duplicate edge" guarantees are also backed by a DB FK + unique constraint, so a race can't corrupt the store.
-- **Ordering tension — pull by `recordedAt`, relate by `occurredAt`.** The reconcile path _checkpoints_ on `recordedAt` (monotonic capture order — safe progress for an append-only log). But an edge's **`observedAt` must be the source event's `occurredAt`** (the built `KnowledgeGraphEdge` stores `observedAt`), and `reinforce` keeps the _latest_ `observedAt`. Late-arriving events — and SQS's unordered delivery (`feature-event-publication.md` §7) — mean arrival order ≠ `occurredAt` order. So: **sort each batch/page by `occurredAt` before the relate step**, regardless of which driver produced it. Mapping is explicit: `edge.observedAt = entry.occurredAt`.
-- **Poison events.** A body that can't be parsed/extracted must **not wedge progress**. Record it in the ledger as `failed` with an attempt count; after N attempts it's parked (the SQS message goes to the **DLQ** — `feature-event-publication.md` §7), the cursor moves past it, and a human/alert handles the backlog. One bad event never blocks the pipeline.
-- **Back-pressure & cost.** The cost center is extraction + embedding. Controls: a **bounded batch/page size**, **non-overlapping runs** (the sleep+jitter loop `await`s the previous run before sleeping — ADR `20260529`), a **per-run budget** (max events / max model calls), the SQS **visibility timeout sized above worst-case LLM+embedding latency** (ADR `20260529` follow-up), and batching extractor/embedder calls across a run. These are non-functional constraints, not afterthoughts.
+- **Transaction boundary.** Per Approach A of the domain, node and edge are separate aggregates. A run wraps its writes — **nodes + edges + ledger rows** — in a **context-owned unit-of-work** (§4), so an SQS batch commits atomically while we are still on one Aurora Postgres (ADR [`20260523-consolidated-aurora-postgresql`](../../decision-records/server/20260523-consolidated-aurora-postgresql.md)). When the graph store later splits out (e.g. Neptune), this degrades to _accepted eventual consistency_ (domain §8) — the "no dangling edge / no duplicate edge" guarantees are also backed by a DB FK + unique constraint, so a race can't corrupt the store.
+- **Ordering — relate by `occurredAt`.** An edge's **`observedAt` must be the source event's `occurredAt`** (the built `KnowledgeGraphEdge` stores `observedAt`), and `reinforce` keeps the _latest_ `observedAt`. SQS delivers unordered (`feature-event-publication.md` §7) and events can arrive late, so delivery order ≠ `occurredAt` order. So: **sort each SQS batch by `occurredAt` before the relate step**. Mapping is explicit: `edge.observedAt = entry.occurredAt`.
+- **Poison events.** A body that can't be parsed/extracted must **not wedge the stream**. Record it in the ledger as `failed` with an attempt count; after N attempts the SQS message is parked in the **DLQ** (`feature-event-publication.md` §7) and a human/alert handles the backlog. One bad event never blocks the pipeline.
+- **Back-pressure & cost.** The cost center is extraction + embedding. Controls: a **bounded SQS batch size** (and consumer concurrency), the SQS **visibility timeout sized above worst-case LLM+embedding latency** (ADR `20260529` follow-up), a **per-run budget** (max events / max model calls), and batching extractor/embedder calls across a message batch. Embedding is off the hot path (resolution sub-doc), so its rate limits don't back-pressure enrichment. These are non-functional constraints, not afterthoughts.
 
 ---
 
@@ -71,7 +70,6 @@ export interface KnowledgeContext {
   nodes: KnowledgeGraphNodeRepository; // resolution sub-doc §4
   edges: KnowledgeGraphEdgeRepository; // resolution sub-doc §4
   ledger: ProcessedEventLedger;
-  checkpoint: CheckpointStore; // event consumption sub-doc §3
 }
 export interface UnitOfWork {
   // commit when `work` resolves, roll back if it throws
@@ -81,5 +79,5 @@ export interface UnitOfWork {
 
 > **Unit-of-work is a context-owned outbound port, not a platform import.** The ingestion context already establishes this pattern — `@repo/server-ingestion`'s `UnitOfWork` exposes an `IngestionContext { events, publisher }` and runs `transaction(ctx => …)`, implemented by `UnitOfWorkPg` in `-infra`. The KG layer mirrors it with a `KnowledgeContext`. (`@repo/server-platform` is documented as eventually owning a shared UoW primitive — "to come" — but today each context declares its own port and `-infra` adapter.)
 
-The enrichment routine (event consumption sub-doc §5) enlists these in one `transaction`: `ctx.nodes.saveMany(...)` + `ctx.edges.saveMany(...)` + `ctx.ledger.record(...)`, plus `ctx.checkpoint.save(...)` on the reconcile path only. Atomicity here is what makes at-least-once redelivery safe — a crash before commit leaves no partial graph and no ledger row, so the event is cleanly reprocessed.
+The enrichment routine (event consumption sub-doc §5) enlists these in one `transaction`: `ctx.nodes.saveMany(...)` + `ctx.edges.saveMany(...)` + `ctx.ledger.record(...)`. Atomicity here is what makes at-least-once redelivery safe — a crash before commit leaves no partial graph and no ledger row, so the event is cleanly reprocessed on the next SQS delivery.
 </content>

--- a/docs/thoughts/feature-knowledge-graph-processing-idempotency.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-idempotency.md
@@ -1,0 +1,85 @@
+# Knowledge Graph Processing — Idempotency, Consistency & Multi-Tenancy
+
+Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-graph-processing.md). Covers at-least-once safety, the transaction boundary, failure handling, and resolving a `graphId` per event. Sibling sub-docs: [event consumption](./feature-knowledge-graph-processing-event-consumption.md), [extraction](./feature-knowledge-graph-processing-extraction.md), [resolution & embedding](./feature-knowledge-graph-processing-resolution.md).
+
+---
+
+## 1. Idempotency & delivery semantics
+
+Processing is **at-least-once** by design (`feature-event-publication.md` §2; ADR [`20260524`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)): the relay re-publishes after a crash, SQS redelivers, and the reconcile poll (event consumption sub-doc) can re-see an event the push path already handled. Therefore **writes must be idempotent**.
+
+The domain _gives_ us idempotent writes — **but only if resolution is stable**:
+
+- Re-asserting an edge triple `(from, to, relationship)` **reinforces** instead of duplicating.
+- `attachEvents` unions provenance — re-adding an `eventId` is a no-op.
+
+The threat: **LLM extraction is non-deterministic** (extraction sub-doc §1), so the _same_ event reprocessed can yield slightly different candidates, which could resolve to _different_ nodes and break that stability.
+
+**Decision: anchor idempotency on the deterministic `eventId`, not on extractor output. Keep two distinct mechanisms:**
+
+| Mechanism                   | Question it answers                          | Key                                                        | Why separate                                                                       |
+| --------------------------- | -------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Checkpoint / cursor**     | "How far have we _pulled_?"                  | `recordedAt` high-water mark                               | Progress only. Append-only log ⇒ monotonic, safe. Backs the SQS push (event consumption sub-doc §1). |
+| **Processed-events ledger** | "Was this event's _effect_ already applied?" | `(eventId, extractorVersion) → status, factHash, attempts` | **Exactly-once effect.** Skip an already-processed event regardless of LLM jitter or which driver delivered it. |
+
+Layered guards beneath the ledger: **deterministic candidate keys** (normalized name+type — resolution sub-doc §1/§3) so even a re-extraction resolves to the _same_ node; and **`factHash`** of `(eventId, normalized-fact)` to skip re-asserting a fact already recorded (avoids confidence churn).
+
+**Extractor versioning is a feature, not a bug.** Bumping `extractorVersion` (returned by the gateway — extraction sub-doc §3) makes the ledger _miss_, so events are legitimately reprocessed under the better extractor — provenance grows, edges reinforce, nothing duplicates. That is exactly the desired "the graph improves as the extractor improves" behavior.
+
+---
+
+## 2. Cross-cutting consistency & failure
+
+- **Transaction boundary.** Per Approach A of the domain, node and edge are separate aggregates. A run wraps its writes — **nodes + edges + ledger rows + (reconcile only) checkpoint** — in a **context-owned unit-of-work** (§4), so a page commits atomically while we are still on one Aurora Postgres (ADR [`20260523-consolidated-aurora-postgresql`](../../decision-records/server/20260523-consolidated-aurora-postgresql.md)). When the graph store later splits out (e.g. Neptune), this degrades to _accepted eventual consistency_ (domain §8) — the "no dangling edge / no duplicate edge" guarantees are also backed by a DB FK + unique constraint, so a race can't corrupt the store.
+- **Ordering tension — pull by `recordedAt`, relate by `occurredAt`.** The reconcile path _checkpoints_ on `recordedAt` (monotonic capture order — safe progress for an append-only log). But an edge's **`observedAt` must be the source event's `occurredAt`** (the built `KnowledgeGraphEdge` stores `observedAt`), and `reinforce` keeps the _latest_ `observedAt`. Late-arriving events — and SQS's unordered delivery (`feature-event-publication.md` §7) — mean arrival order ≠ `occurredAt` order. So: **sort each batch/page by `occurredAt` before the relate step**, regardless of which driver produced it. Mapping is explicit: `edge.observedAt = entry.occurredAt`.
+- **Poison events.** A body that can't be parsed/extracted must **not wedge progress**. Record it in the ledger as `failed` with an attempt count; after N attempts it's parked (the SQS message goes to the **DLQ** — `feature-event-publication.md` §7), the cursor moves past it, and a human/alert handles the backlog. One bad event never blocks the pipeline.
+- **Back-pressure & cost.** The cost center is extraction + embedding. Controls: a **bounded batch/page size**, **non-overlapping runs** (the sleep+jitter loop `await`s the previous run before sleeping — ADR `20260529`), a **per-run budget** (max events / max model calls), the SQS **visibility timeout sized above worst-case LLM+embedding latency** (ADR `20260529` follow-up), and batching extractor/embedder calls across a run. These are non-functional constraints, not afterthoughts.
+
+---
+
+## 3. `graphId` resolution / multi-tenancy during enrichment
+
+**The gap the domain deferred but this layer cannot.** Every `KnowledgeGraphNode.create` and `KnowledgeGraphEdge.create` requires a `graphId` (confirmed in the built aggregates), yet an event entry carries only `tags` + `body`. _Which graph does an event belong to?_ The domain doc **explicitly defers** multi-tenancy/scope (§10) while namespacing everything by `graphId`. The application layer **must** resolve a concrete `graphId` for every event just to call the domain at all — so it _completes_ the deferred decision (not contradicts it).
+
+**Decision: a `GraphResolution` policy/port** mapping `event.tags` (e.g. an `org` / `workspace` tag) → `KnowledgeGraphId`, with a **Phase-0 default of a single well-known graph**. Keeping it a port means that when real multi-tenancy/isolation arrives (its own discovery), it's a policy swap — the enrichment use cases don't change. Resolution happens **once per event**, before extraction, and the resolved `graphId` flows into every node/edge created from that event.
+
+---
+
+## 4. Outbound ports
+
+```ts
+// processed-event.ledger.ts — exactly-once effect (§1)
+export type ProcessStatus = "done" | "failed";
+export interface ProcessedEventLedger {
+  seen(eventId: EventId, extractorVersion: string): Promise<boolean>;
+  record(
+    eventId: EventId,
+    extractorVersion: string,
+    status: ProcessStatus,
+    factHash: string,
+    attempts: number,
+  ): Promise<void>;
+}
+
+// graph-resolution.policy.ts — §3, the multi-tenancy gap
+export interface GraphResolution {
+  resolve(tags: Record<string, string>): KnowledgeGraphId;
+}
+
+// unit-of-work.ts — context-owned, mirroring @repo/server-ingestion's UnitOfWork
+export interface KnowledgeContext {
+  nodes: KnowledgeGraphNodeRepository; // resolution sub-doc §4
+  edges: KnowledgeGraphEdgeRepository; // resolution sub-doc §4
+  ledger: ProcessedEventLedger;
+  checkpoint: CheckpointStore; // event consumption sub-doc §3
+}
+export interface UnitOfWork {
+  // commit when `work` resolves, roll back if it throws
+  transaction<T>(work: (ctx: KnowledgeContext) => Promise<T>): Promise<T>;
+}
+```
+
+> **Unit-of-work is a context-owned outbound port, not a platform import.** The ingestion context already establishes this pattern — `@repo/server-ingestion`'s `UnitOfWork` exposes an `IngestionContext { events, publisher }` and runs `transaction(ctx => …)`, implemented by `UnitOfWorkPg` in `-infra`. The KG layer mirrors it with a `KnowledgeContext`. (`@repo/server-platform` is documented as eventually owning a shared UoW primitive — "to come" — but today each context declares its own port and `-infra` adapter.)
+
+The enrichment routine (event consumption sub-doc §5) enlists these in one `transaction`: `ctx.nodes.saveMany(...)` + `ctx.edges.saveMany(...)` + `ctx.ledger.record(...)`, plus `ctx.checkpoint.save(...)` on the reconcile path only. Atomicity here is what makes at-least-once redelivery safe — a crash before commit leaves no partial graph and no ledger row, so the event is cleanly reprocessed.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing-resolution.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-resolution.md
@@ -104,7 +104,7 @@ export interface KnowledgeGraphEdgeRepository {
 }
 ```
 
-The node/edge repositories are also enlisted in the transactional write of the main enrichment flow — see the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md) for the unit-of-work that wraps `saveMany` + ledger + checkpoint.
+The node/edge repositories are also enlisted in the transactional write of the main enrichment flow — see the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md) for the unit-of-work that wraps `saveMany` + ledger.
 
 ## 5. Inbound (driving) ports
 

--- a/docs/thoughts/feature-knowledge-graph-processing-resolution.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-resolution.md
@@ -1,0 +1,124 @@
+# Knowledge Graph Processing — Entity Resolution & Embedding
+
+Sub-document of [`feature-knowledge-graph-processing.md`](./feature-knowledge-graph-processing.md). Covers deciding a candidate entity **is** an existing node, the embedding lifecycle, and node-body canonicalization. Sibling sub-docs: [event consumption](./feature-knowledge-graph-processing-event-consumption.md), [extraction](./feature-knowledge-graph-processing-extraction.md), [idempotency & consistency](./feature-knowledge-graph-processing-idempotency.md).
+
+---
+
+## 1. Entity resolution / dedup
+
+The hardest stage: deciding a candidate entity **is** an existing node. **Decision: a conservative hybrid with deferred merge**, and a clean **split of responsibility** between an I/O port and a pure decision.
+
+1. **Deterministic natural key first.** Normalize `(type, key)` (e.g. `PERSON` + canonical email/handle) and look it up via `KnowledgeGraphNodeRepository.findByNaturalKey`. Exact, cheap, deterministic.
+2. **Vector ANN second.** If no key hit, embed the candidate body and ask the resolution index for similar same-type nodes above a threshold.
+3. **Defer the hard cases.** If matches are ambiguous (near-threshold, multiple plausible), **do not guess in the hot path** — create the node _and_ record a `DUPLICATE_OF` candidate that `MergeDuplicateNodes` reconciles later (reusing the domain's `mergeNodes`). Provenance is never lost (`eventIds` only grow), so deferring is safe.
+
+**Port vs domain service — split by responsibility** (mirroring how `GraphRelation.relate` takes already-loaded aggregates):
+
+- The **I/O** — natural-key lookup, ANN search — is an outbound port (`NodeResolutionIndex` + repo lookups).
+- The **decision** — _"this candidate is `Resolved(nodeId)` / `New` / `Ambiguous`"_ — is a **pure domain service** `EntityResolution.classify(candidate, matches)`, operating on already-fetched matches. This keeps the _threshold policy_ pure and unit-testable instead of buried in an adapter. It is the one new pure type this layer adds to the domain (`entity-resolution.domain-service.ts`).
+
+| Strategy                             | Pro                                                                                    | Con                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Deterministic key only               | Fast, deterministic, no model cost                                                     | Misses fuzzy duplicates ("Alice" vs "Alice Smith") → fragmentation        |
+| Vector similarity only               | Catches fuzzy duplicates                                                               | Threshold tuning; risk of **over-merging** distinct entities; model cost |
+| LLM canonicalization                 | Highest recall                                                                         | Cost, latency, non-determinism, hardest to make idempotent               |
+| **Hybrid + deferred merge (chosen)** | Deterministic where possible, fuzzy where needed, **never over-merges synchronously** | Two passes; the merge backlog must be drained                            |
+
+The bias is **conservative**: prefer transient fragmentation (fixable by a later merge) over irreversible over-merging in the hot path.
+
+---
+
+## 2. Re-embedding & the `EmbedNodes` lifecycle
+
+Embedding is split out of `EnrichEvents` because the domain treats it as a distinct lifecycle phase, not a one-shot at birth (parent doc §4). The built `KnowledgeGraphNode.create` confirms this — it always sets `embedding: null`.
+
+|                        | Embedding split into `EmbedNodes`                                                                                          | Embedding inline in `EnrichEvents`                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Domain signal**      | Embedding is **optional at birth**, assigned later via `assignEmbedding`, recording a _separate_ `NodeEmbedded` event.    | Fights the domain — forces a node to be born embedded.    |
+| **Failure isolation**  | An embedding-API outage **does not block graph construction**; nodes are born `embedding: null` and embedded on the next run. | An embedding outage wedges the whole enrichment run.      |
+| **Cost / rate limits** | The most expensive, most rate-limited call is isolated and independently retriable/batchable.                             | Couples graph mutation throughput to embedding throughput. |
+| **Reuse**              | The same job handles **re-embedding** on body revision / model change (below).                                            | Re-embedding needs separate plumbing anyway.              |
+
+**`EmbedNodes` triggers** — embedding is not a one-shot at birth:
+
+1. **New node** — born with `embedding: null`; embed it. In Phase 0 the job simply scans for nodes where `embedding IS NULL` on its own jittered loop (ADR [`20260529`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md)) — no event bus required. (A `NodeCreated` domain-event trigger is a later graduation once a KG-side publisher exists.)
+2. **Body revised** — `reviseBody` changes the canonical text, so the existing embedding is **stale**; re-embed.
+3. **Model drift** — a node whose embedding model ≠ the graph's policy model (`KnowledgeGraph.accepts` returns false) must be **re-embedded** to satisfy the graph-wide embedding policy. (`KnowledgeGraph` carries `embeddingModel` + `embeddingDimensions`.)
+
+---
+
+## 3. Node body canonicalization
+
+**Node body canonicalization is a real decision, not a detail.** The `NodeBody` text drives _both_ the embedding _and_ the natural key for resolution (§1) — so it silently governs over/under-merge. ("Alice", "alice@corp", "Alice Smith" → one node or three?)
+
+**Decision: a conservative Phase-0 canonicalization policy** at the extractor/resolution boundary — trim, case-fold, prefer a stable identifier (email/handle) as the `naturalKey` when present, and keep a human-readable display `body`. Make it explicit so fragmentation is a tuning knob, not an accident. (`NodeBody` enforces 1–10,000 trimmed chars; canonicalization is policy layered above that, not a domain invariant.)
+
+---
+
+## 4. Outbound ports
+
+```ts
+// embedding.gateway.ts
+export interface EmbeddingGateway {
+  embed(texts: string[], model: string): Promise<number[][]>; // batched
+}
+
+// node-resolution.index.ts — ANN over node embeddings (may share the pgvector adapter)
+export interface NodeMatch {
+  id: NodeId;
+  score: number;
+}
+export interface NodeResolutionIndex {
+  findSimilar(
+    graphId: KnowledgeGraphId,
+    type: NodeType,
+    vector: number[],
+    threshold: number,
+    k: number,
+  ): Promise<NodeMatch[]>;
+}
+
+// knowledge-graph-node.repository.ts
+export interface KnowledgeGraphNodeRepository {
+  findById(id: NodeId): Promise<KnowledgeGraphNode | null>;
+  findByNaturalKey(
+    graphId: KnowledgeGraphId,
+    type: NodeType,
+    key: string,
+  ): Promise<KnowledgeGraphNode | null>;
+  findNeedingEmbedding(model: string, limit: number): Promise<KnowledgeGraphNode[]>; // EmbedNodes scan
+  saveMany(nodes: KnowledgeGraphNode[]): Promise<void>;
+}
+
+// knowledge-graph-edge.repository.ts
+export interface KnowledgeGraphEdgeRepository {
+  findByTriple(
+    graphId: KnowledgeGraphId,
+    fromId: NodeId,
+    toId: NodeId,
+    rel: RelationshipType,
+  ): Promise<KnowledgeGraphEdge | null>;
+  findDuplicateOf(limit: number): Promise<KnowledgeGraphEdge[]>; // MergeDuplicateNodes drain
+  saveMany(edges: KnowledgeGraphEdge[]): Promise<void>;
+  repointIncidentEdges(from: NodeId, to: NodeId): Promise<void>; // for merge
+}
+```
+
+The node/edge repositories are also enlisted in the transactional write of the main enrichment flow — see the [idempotency & consistency sub-doc](./feature-knowledge-graph-processing-idempotency.md) for the unit-of-work that wraps `saveMany` + ledger + checkpoint.
+
+## 5. Inbound (driving) ports
+
+```ts
+// embed-nodes.use-case.ts
+export interface EmbedNodes {
+  execute(input: { nodeIds?: NodeId[]; limit: number }): Promise<Result<void>>;
+}
+
+// merge-duplicate-nodes.use-case.ts
+export interface MergeDuplicateNodes {
+  execute(input: { limit: number }): Promise<Result<void>>;
+}
+```
+
+`EmbedNodes` with no `nodeIds` scans `findNeedingEmbedding` (the Phase-0 trigger); with `nodeIds` it targets a specific set (e.g. after `reviseBody`). `MergeDuplicateNodes` drains `findDuplicateOf`, folds provenance into the survivor via `attachEvents`, and re-points incident edges — one cross-aggregate transaction per merge.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing-tasks.md
+++ b/docs/thoughts/feature-knowledge-graph-processing-tasks.md
@@ -1,0 +1,137 @@
+# Knowledge Graph Processing — Implementation Tasks (use-case by use-case)
+
+The implementation breakdown for the enrichment application layer designed in [`feature-knowledge-graph-processing.md`](./feature-knowledge-graph-processing.md) and its sub-docs ([consumption](./feature-knowledge-graph-processing-event-consumption.md), [extraction](./feature-knowledge-graph-processing-extraction.md), [resolution & embedding](./feature-knowledge-graph-processing-resolution.md), [idempotency](./feature-knowledge-graph-processing-idempotency.md)). This is the **task list**, not new design — every "why" lives in those docs; here we only say _what to build, where, in what order, and how to know it's done_.
+
+**How to read this.** Work is split into a **Shared foundation** (domain mutators + ports that more than one use case needs) and then **one section per use case**. Each use case lists its sub-tasks across the layers it touches (domain → ports → use-case → infra → worker → tests), names the foundation tasks it depends on, and states a verification check per the goal-driven discipline in `AGENTS.md`.
+
+**Legend.** `[ ]` not started · `D#` domain · `P#` port · `EE#` EnrichEvents · `EN#` EmbedNodes · `MD#` MergeDuplicateNodes. Paths follow `project-structure.md` §9 and the layout in the parent doc §7.
+
+---
+
+## Status snapshot (2026-05)
+
+- **Domain (`@repo/server-knowledge`):** the three aggregates + value objects + closed vocabularies + `Invalid*` errors exist, exposing **`create`/`restore` only**. No mutators, no domain events, no domain services.
+- **Application layer:** none (`packages/server-knowledge/src/application/` does not exist).
+- **Infra (`@repo/server-knowledge-infra`):** stub only.
+- **Enricher app (`apps/server-knowledge-worker`):** stub (health route only).
+
+So almost everything below is greenfield. The one structural pattern to copy is the **ingestion** context — `@repo/server-ingestion` already shows the use-case + `UnitOfWork` + `EventPublisher` shape, and `@repo/server-ingestion-infra` shows the `*.repository.pg.ts` + outbox/relay adapters.
+
+---
+
+## Shared foundation
+
+These are dependencies for more than one use case; build them first.
+
+### Domain prerequisites (owed by `feature-knowledge-graph.md`)
+
+These are **domain-layer** tasks (mutators/events/services the domain doc designed but never shipped). They live in `@repo/server-knowledge`, follow `.claude/rules/server-hexagonal-domain-layer.md` (zod schema, `parseProps`/`parsePropsOrThrow`, `defineError`, `Result` from expected failures), and must land before the use cases that call them.
+
+- [ ] **D1 — Node mutators.** Add to `knowledge-graph-node.aggregate.ts`: `attachEvents(eventIds, now)` (union into `eventIds`, no-op on duplicates, `metadata.touch`), `assignEmbedding(embedding)`, `reviseBody(body, now)`. → _verify:_ unit tests prove `attachEvents` is idempotent on a repeated `eventId` and that `assignEmbedding` flips `embedding` from `null`.
+- [ ] **D2 — Edge mutator.** Add `reinforce({ confidence, observedAt, sourceEventIds, now })` to `knowledge-graph-edge.aggregate.ts`: union `sourceEventIds`, keep the **latest** `observedAt`, update confidence. → _verify:_ reinforcing keeps the max `observedAt` and unions provenance.
+- [ ] **D3 — Domain events.** Add `NodeCreated`, `NodeEmbedded`, `NodesRelated` (kernel `DomainEvent`) and record them on the matching factory/mutator via `AggregateRoot.record(...)`. → _verify:_ `pullDomainEvents()` returns the expected event after `create`/`assignEmbedding`/`relate`.
+- [ ] **D4 — `GraphRelation` domain service.** `graph-relation.domain-service.ts`: `relate({ graphId, fromId, toId, relationship, confidence, observedAt, sourceEventIds, existing, now })` → create a new edge or `reinforce` the passed-in `existing` one. Pure; takes already-loaded aggregates. → _verify:_ returns a new edge when `existing` is null, a reinforced one otherwise.
+- [ ] **D5 — `KnowledgeGraph.accepts(embedding)`.** Policy on the graph root comparing an embedding's `model`/`dimensions` to the graph's `embeddingModel`/`embeddingDimensions`. → _verify:_ false on model/dimension mismatch.
+- [ ] **D6 — Merge semantics.** A pure helper for folding a duplicate into a survivor (provenance via `attachEvents`); the edge re-point is I/O (P-layer). → _verify:_ survivor gains the duplicate's `eventIds`.
+
+> If the team prefers, D1–D6 can be tracked in `feature-knowledge-graph.md`'s own task list instead; they are listed here because the use cases below are blocked on them.
+
+### Shared ports (pure, `application/ports/outbound/`)
+
+Interfaces only — no implementations (`.claude/rules/server-hexagonal-application-layer.md`). Exact signatures are in the design sub-docs.
+
+- [ ] **P1 — `KnowledgeGraphNodeRepository`** (`knowledge-graph-node.repository.ts`): `findById`, `findByNaturalKey`, `findNeedingEmbedding`, `saveMany`. (resolution sub-doc §4)
+- [ ] **P2 — `KnowledgeGraphEdgeRepository`** (`knowledge-graph-edge.repository.ts`): `findByTriple`, `findDuplicateOf`, `saveMany`, `repointIncidentEdges`. (resolution sub-doc §4)
+- [ ] **P3 — `UnitOfWork` + `KnowledgeContext`** (`unit-of-work.ts`): `transaction(ctx => …)` exposing `{ nodes, edges, ledger }`. Mirror `@repo/server-ingestion`'s `UnitOfWork`. (idempotency sub-doc §4)
+- [ ] **P4 — `EmbeddingGateway`** (`embedding.gateway.ts`): `embed(texts, model)`. (resolution sub-doc §4)
+
+---
+
+## Use case 1 — `EnrichEvents` (SQS push)
+
+The hot path: one SQS message batch → read bodies → extract → resolve → upsert nodes → relate edges → record ledger, in one transaction. **Depends on:** D1, D2, D3, D4, P1, P2, P3.
+
+### Domain
+
+- [ ] **EE1 — `EntityResolution` domain service.** `entity-resolution.domain-service.ts`: `classify(candidate, matches) → Resolved(nodeId) | New | Ambiguous`. Pure decision over already-fetched matches; the only new domain type this layer adds. (resolution sub-doc §1) → _verify:_ key-hit ⇒ `Resolved`; no match ⇒ `New`; near-threshold/multiple ⇒ `Ambiguous`.
+
+### Ports (pure)
+
+- [ ] **EE2 — `EventSourceReader`** (`event-source.reader.ts`): `findByIds(ids)` returning the KG-owned `EventEntry` DTO. ACL — never imports ingestion's `Event`. (consumption sub-doc §3)
+- [ ] **EE3 — `EntityExtractorGateway`** (`entity-extractor.gateway.ts`): `extract(entry) → ExtractionResult` with `CandidateNode`/`CandidateEdge`/`extractorVersion`. (extraction sub-doc §3)
+- [ ] **EE4 — `NodeResolutionIndex`** (`node-resolution.index.ts`): `findSimilar(graphId, type, vector, threshold, k)`. (resolution sub-doc §4)
+- [ ] **EE5 — `GraphResolution`** (`graph-resolution.policy.ts`): `resolve(tags) → KnowledgeGraphId`. (idempotency sub-doc §4)
+- [ ] **EE6 — `ProcessedEventLedger`** (`processed-event.ledger.ts`): `seen(eventId, version)`, `record(...)`. (idempotency sub-doc §4)
+
+### Use case (pure)
+
+- [ ] **EE7 — `EnrichEvents` inbound port + `EnrichEventsUseCase`** (`enrich-events.use-case.ts`): `execute({ eventIds }) → Result<EnrichmentReport>`. Implements the orchestration in consumption sub-doc §5: ledger filter → sort by `occurredAt` → per-entry resolve/relate → one `UnitOfWork.transaction` (nodes + edges + ledger). → _verify:_ a use-case test with in-memory fakes (no DB) proves: new entity ⇒ `create`; repeated `eventId` ⇒ `attachEvents` no-op; re-asserted triple ⇒ `reinforce`; already-in-ledger ⇒ skipped.
+
+### Infra (`@repo/server-knowledge-infra`)
+
+- [ ] **EE8 — Event-table reader** (`read/event-source.reader.pg.ts`): `SELECT id, occurred_at, tags, body FROM events WHERE id = ANY(...)` → `EventEntry`. (consumption sub-doc §2)
+- [ ] **EE9 — Node & edge pg repos** (`persistence/*.repository.pg.ts`) implementing P1/P2 against Prisma; new `knowledge_graph_node` / `knowledge_graph_edge` tables + unique constraint on the edge triple + FK to nodes (`server-database` migration).
+- [ ] **EE10 — `UnitOfWorkPg`** (`persistence/unit-of-work.pg.ts`) implementing P3; copy the ingestion `UnitOfWorkPg` transaction-context shape.
+- [ ] **EE11 — Processed-events ledger** adapter + table (`persistence/processed-event.ledger.pg.ts` + migration): `(event_id, extractor_version)` PK, `status`, `fact_hash`, `attempts`.
+- [ ] **EE12 — `GraphResolution` policy adapter** (`gateways/graph-resolution.single-graph.ts`): Phase-0 single well-known `graphId`. (idempotency sub-doc §3)
+- [ ] **EE13 — LLM extractor gateway** (`gateways/entity-extractor.llm.ts`): hybrid rules + structured-output, vocabulary enforced **in the adapter**; returns `extractorVersion`. (extraction sub-doc §1–§3)
+- [ ] **EE14 — pgvector resolution index** (`persistence/node-resolution.index.pg.ts`) implementing EE4 (may share the embedding column / HNSW index).
+
+### Worker (`apps/server-knowledge-worker`)
+
+- [ ] **EE15 — SQS consumer job** (`jobs/enrich-events.job.ts`): long-poll loop → map message batch to `eventIds` → `EnrichEvents.execute` → delete on success; rely on visibility-timeout + DLQ for failures. (consumption sub-doc §1)
+- [ ] **EE16 — Composition wiring** (`composition/`): construct adapters from config and inject into `EnrichEventsUseCase`; size the SQS visibility timeout above worst-case LLM+embedding latency (idempotency sub-doc §2, ADR `20260529` follow-up).
+- [ ] **EE17 — End-to-end test:** enqueue → consume → graph rows written; redeliver same message ⇒ no duplicate nodes/edges (ledger + provenance hold). → _verify:_ second delivery changes nothing.
+
+---
+
+## Use case 2 — `EmbedNodes`
+
+Assign/refresh embeddings for nodes that need one, off the hot path. **Depends on:** D1 (`assignEmbedding`), D5 (`accepts`), P1 (`findNeedingEmbedding`/`saveMany`), P3, P4.
+
+### Use case (pure)
+
+- [ ] **EN1 — `EmbedNodes` inbound port + use case** (`embed-nodes.use-case.ts`): `execute({ nodeIds?, limit }) → Result<void>`. No `nodeIds` ⇒ scan `findNeedingEmbedding(model, limit)`; embed via P4; `node.assignEmbedding(...)`; save. Handles the three triggers (new node, body revised, model drift via D5). (resolution sub-doc §2) → _verify:_ a node born `embedding: null` becomes embedded; a node already matching the graph's model is left untouched.
+
+### Infra
+
+- [ ] **EN2 — Embedder gateway** (`gateways/embedding.openai.ts` or chosen provider) implementing P4, batched.
+- [ ] **EN3 — `findNeedingEmbedding` query** in the node pg repo (EE9): `WHERE embedding IS NULL OR embedding_model <> $policyModel LIMIT n`.
+
+### Worker
+
+- [ ] **EN4 — Jittered loop job** (`jobs/embed-nodes.job.ts`): `do work → sleep(interval + jitter) → repeat`, non-overlapping (ADR `20260529`).
+- [ ] **EN5 — Wiring** in `composition/`.
+- [ ] **EN6 — Test:** outage of the embedder leaves graph construction unaffected and nodes simply embed on the next run. → _verify:_ failure isolation holds.
+
+---
+
+## Use case 3 — `MergeDuplicateNodes`
+
+Drain `DUPLICATE_OF` candidates: fold provenance into the survivor and re-point incident edges. Inherently async + cross-aggregate. **Depends on:** D1 (`attachEvents`), D6 (merge semantics), P1, P2 (`findDuplicateOf`/`repointIncidentEdges`), P3.
+
+### Use case (pure)
+
+- [ ] **MD1 — `MergeDuplicateNodes` inbound port + use case** (`merge-duplicate-nodes.use-case.ts`): `execute({ limit }) → Result<void>`. For each `DUPLICATE_OF`: load both nodes, `survivor.attachEvents(duplicate.eventIds)`, `repointIncidentEdges(duplicate, survivor)`, retire the duplicate — one `UnitOfWork.transaction` per merge. (resolution sub-doc §5) → _verify:_ survivor gains provenance; no edge is left pointing at the retired node; re-running is a no-op.
+
+### Infra
+
+- [ ] **MD2 — `findDuplicateOf` + `repointIncidentEdges`** in the edge pg repo (EE9), in one transaction; respect the edge unique constraint when re-pointing (merge can collide into an existing triple ⇒ reinforce instead of insert).
+
+### Worker
+
+- [ ] **MD3 — Jittered reconciler loop** (`jobs/merge-duplicate-nodes.job.ts`).
+- [ ] **MD4 — Wiring** in `composition/`.
+- [ ] **MD5 — Test:** a `DUPLICATE_OF` pair merges cleanly and a re-point that collides with an existing triple reinforces rather than violating the unique constraint.
+
+---
+
+## Suggested sequencing
+
+1. **Shared foundation** — D1–D6, P1–P4. Nothing else compiles without the domain mutators and core ports.
+2. **`EnrichEvents`** (EE1–EE17) — the spine; delivers a working capture→graph path end to end.
+3. **`EmbedNodes`** (EN1–EN6) — turns nodes searchable; independent once EnrichEvents writes nodes.
+4. **`MergeDuplicateNodes`** (MD1–MD5) — drains the deferred-merge backlog EnrichEvents produces.
+
+EmbedNodes and MergeDuplicateNodes are independent of each other and can proceed in parallel after EnrichEvents lands. Throughout, keep `@repo/server-knowledge` dependency-clean (only `@repo/server-kernel` + `zod`); every adapter task lives in `-infra` or the worker app.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing.md
+++ b/docs/thoughts/feature-knowledge-graph-processing.md
@@ -7,7 +7,7 @@ It is the discovery that two siblings explicitly deferred to "later":
 - [`feature-knowledge-graph.md`](./feature-knowledge-graph.md) designed the **domain** of this context (Approach A — node/edge as independent aggregate roots, a thin graph root, the `GraphRelation` domain service, closed `NodeType`/`RelationshipType` vocabularies, `DUPLICATE_OF` + `mergeNodes` for entity resolution) and ended with _"`application/` — use cases + ports — separate discovery."_ **This is that discovery.**
 - [`feature-event-ingestion.md`](./feature-event-ingestion.md) §7 named the seam that _kicks off_ enrichment. That seam has since been designed in [`feature-event-publication.md`](./feature-event-publication.md) and **built** (outbox → SQS, see §1 below) — so this layer now consumes a seam that exists, not one it has to cope around.
 
-Scope is the **pure application core**: inbound (driving) ports + their use-case implementations, and outbound (driven) port interfaces. Adapters (the LLM extractor, the embedder, the Postgres repositories, the `pgvector` resolution index, the event-log reader, the checkpoint/ledger tables) are named as seams but **not built** — they live in `@repo/server-knowledge-infra`.
+Scope is the **pure application core**: inbound (driving) ports + their use-case implementations, and outbound (driven) port interfaces. Adapters (the LLM extractor, the embedder, the Postgres repositories, the `pgvector` resolution index, the event-log reader, the processed-events ledger table) are named as seams but **not built** — they live in `@repo/server-knowledge-infra`.
 
 > **State of the code (2026-05).** The KG **domain** is on disk: `KnowledgeGraph`, `KnowledgeGraphNode`, `KnowledgeGraphEdge` aggregates, their value objects, the closed `NodeType`/`RelationshipType` vocabularies, and the `Invalid*` errors — currently exposing **`create`/`restore` only**. The mutators and services this layer orchestrates (`attachEvents`, `assignEmbedding`, `reviseBody`, `reinforce`, `GraphRelation.relate`, `EntityResolution.classify`, `mergeNodes`, `KnowledgeGraph.accepts`) are the domain contract from `feature-knowledge-graph.md` and are **not all implemented yet**. The KG **application layer** (everything below) and `@repo/server-knowledge-infra` are still empty. So this remains **a design contract the package should converge toward**, not code on disk.
 
@@ -38,9 +38,8 @@ This doc is **write-side only.** The recall/read path (`RelationshipGraph` trave
 | **Event entry**             | A read DTO `{ id, occurredAt, tags, body }` returned by the event-read port. The app's view of a raw log item — distinct from the domain's id-only `EventId`. |
 | **Candidate**               | A _proposed_ entity or relationship emitted by the extractor from one event entry, **before** resolution. Not yet a node/edge.                                |
 | **Resolution**              | Deciding whether a candidate entity **is** an existing node, is **new**, or is **ambiguous** (defer). Produces a `NodeId`.                                    |
-| **Enrichment run**          | One execution of the enrichment core over a bounded set of event entries (one SQS batch, or one reconcile page).                                              |
-| **Checkpoint / cursor**     | The high-water mark of _progress_ through the log — "events up to here have been pulled." Keyed on `recordedAt`. Backs the SQS push as a catch-up reconciler. |
-| **Processed-events ledger** | The record of _effect_ — "this `eventId` was processed by this extractor version." The idempotency guard. Distinct from the cursor.                           |
+| **Enrichment run**          | One execution of the enrichment core over the event entries named by one SQS message batch.                                                                  |
+| **Processed-events ledger** | The record of _effect_ — "this `eventId` was processed by this extractor version." The idempotency guard against SQS redelivery.                              |
 | **factHash**                | A content hash of `(eventId, normalized-fact)` used to detect "same fact, already asserted" and skip redundant work.                                          |
 | **Extractor version**       | A monotonically-bumped tag for the extraction logic/prompt/model. Reprocessing under a new version is legitimate.                                             |
 
@@ -74,14 +73,13 @@ read events → extract candidates → resolve to nodes → upsert nodes → rel
 
 **One cohesive write core, two drivers, embedding and merging split out.**
 
-| Use case (inbound port)   | Responsibility                                                                                                                          | Driven by                                                                |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| **`EnrichEvents`**        | The hot path: given event ids, read bodies → extract → resolve → upsert nodes → relate edges → record ledger. One transactional run.   | **SQS push** (`apps/server-knowledge-worker` consumer).                  |
-| **`ReconcileEnrichment`** | The safety net: pull a bounded page `WHERE recordedAt > cursor`, run the **same** core, advance the cursor.                            | **Jittered catch-up loop** (same app, longer interval — ADR `20260529`). |
-| **`EmbedNodes`**          | Assign/refresh embeddings for nodes that need one. Calls the embedding gateway, then `node.assignEmbedding(...)`.                       | Jittered loop scanning nodes needing embedding (resolution sub-doc).     |
-| **`MergeDuplicateNodes`** | Drain `DUPLICATE_OF` edges: fold provenance into the survivor (`attachEvents`) and re-point incident edges. Reuses the merge semantics. | Jittered reconciler loop.                                                |
+| Use case (inbound port)   | Responsibility                                                                                                                          | Driven by                                                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **`EnrichEvents`**        | Given event ids, read bodies → extract → resolve → upsert nodes → relate edges → record ledger. One transactional run.                 | **SQS push** (`apps/server-knowledge-worker` consumer).             |
+| **`EmbedNodes`**          | Assign/refresh embeddings for nodes that need one. Calls the embedding gateway, then `node.assignEmbedding(...)`.                       | Jittered loop scanning nodes needing embedding (resolution sub-doc). |
+| **`MergeDuplicateNodes`** | Drain `DUPLICATE_OF` edges: fold provenance into the survivor (`attachEvents`) and re-point incident edges. Reuses the merge semantics. | Jittered reconciler loop.                                            |
 
-`EnrichEvents` and `ReconcileEnrichment` share one internal enrichment routine and the same **processed-events ledger** guard, so a message processed by the push path and later re-seen by the reconcile poll is a no-op. The trigger model — in-process **sleep + jitter** loops, not cron — is decided in ADR [`20260529-in-process-sleep-jitter-worker-trigger`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md); SQS push is the hot path, the cursor poll backs it up.
+Enrichment is driven solely by **SQS push** — one recorded event per message, consumed by `apps/server-knowledge-worker`. The **processed-events ledger** guard makes at-least-once redelivery safe: a message re-delivered by SQS is a no-op. There is **no cursor/reconcile path** — completeness rests on SQS at-least-once delivery plus a DLQ for poison messages, and the `events` table stays the source of truth for any future manual backfill. `EmbedNodes` and `MergeDuplicateNodes` run on their own in-process **sleep + jitter** loops (ADR [`20260529-in-process-sleep-jitter-worker-trigger`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md)), not cron.
 
 **Why split embedding out** (rather than embedding inline in `EnrichEvents`): the domain makes embedding **optional at birth** (`create` always sets `embedding: null`) and assigns it later via `assignEmbedding`, recording a separate `NodeEmbedded` event — a distinct lifecycle phase. An embedding-API outage then **does not block graph construction**, the most expensive/rate-limited call is isolated and independently retriable, and the same job handles **re-embedding** on body revision / model change. Full reasoning in the [resolution & embedding sub-doc](./feature-knowledge-graph-processing-resolution.md).
 
@@ -93,10 +91,10 @@ read events → extract candidates → resolve to nodes → upsert nodes → rel
 
 The depth lives in four focused sub-docs. Read in pipeline order:
 
-1. **[Event consumption & cross-context integration](./feature-knowledge-graph-processing-event-consumption.md)** — how enrichment is triggered (SQS push + cursor reconcile) and how it reads events that belong to the ingestion context behind an anti-corruption `EventSourceReader` port. Ports: `EventSourceReader`, `CheckpointStore`; inbound `EnrichEvents` / `ReconcileEnrichment`; the enrichment orchestration.
+1. **[Event consumption & cross-context integration](./feature-knowledge-graph-processing-event-consumption.md)** — how enrichment is triggered (SQS push) and how it reads events that belong to the ingestion context behind an anti-corruption `EventSourceReader` port. Port: `EventSourceReader`; inbound `EnrichEvents`; the enrichment orchestration.
 2. **[Extraction](./feature-knowledge-graph-processing-extraction.md)** — opaque `body` → candidates already typed to the closed vocabulary; hybrid rules + LLM routed on `tags`; vocabulary enforced in the gateway; the source-signal → relationship mapping; `DERIVED_FROM` vs `eventIds`. Port: `EntityExtractorGateway`.
 3. **[Entity resolution & embedding](./feature-knowledge-graph-processing-resolution.md)** — deciding a candidate **is** an existing node (deterministic key → vector ANN → defer); the pure `EntityResolution.classify` decision; `EmbedNodes` triggers; node-body canonicalization. Ports: `NodeResolutionIndex`, `EmbeddingGateway`, the node/edge repositories.
-4. **[Idempotency, consistency & multi-tenancy](./feature-knowledge-graph-processing-idempotency.md)** — at-least-once safety (ledger vs cursor, `factHash`, extractor versioning); the transaction boundary (context-owned unit-of-work); ordering / poison events / back-pressure; resolving a `graphId` per event. Ports: `ProcessedEventLedger`, `GraphResolution`, `UnitOfWork`.
+4. **[Idempotency, consistency & multi-tenancy](./feature-knowledge-graph-processing-idempotency.md)** — at-least-once safety (the processed-events ledger, `factHash`, extractor versioning); the transaction boundary (context-owned unit-of-work); ordering / poison events / back-pressure; resolving a `graphId` per event. Ports: `ProcessedEventLedger`, `GraphResolution`, `UnitOfWork`.
 
 ---
 
@@ -104,12 +102,12 @@ The depth lives in four focused sub-docs. Read in pipeline order:
 
 **Decisions taken (with the rejected alternative):**
 
-- **Consume events → SQS push (hot path) + cursor reconcile (safety net)** ([consumption](./feature-knowledge-graph-processing-event-consumption.md)). The original draft chose cron batch-pull because the publisher seam did not exist; it now does (outbox → SQS, ADR `20260524`), so per-event push is the hot path and the cursor poll degrades to a reconciler — exactly the graduation the draft anticipated. Both drive the **same** use-case core; the trigger is a sleep + jitter loop (ADR `20260529`), not cron.
+- **Consume events → SQS push only** ([consumption](./feature-knowledge-graph-processing-event-consumption.md)). The original draft chose cron batch-pull because the publisher seam did not exist; it now does (outbox → SQS, ADR `20260524`), so enrichment is driven per-event off the queue. No cursor/reconcile path — at-least-once delivery, a DLQ, and the `eventId` ledger cover redelivery and poison messages; the `events` table stays the source of truth for any manual backfill. A scheduled reconciler can be added later behind a new driving adapter over the same use case if evidence demands it.
 - **Integration → shared-DB read behind an ACL port** ([consumption](./feature-knowledge-graph-processing-event-consumption.md)), not payload-in-event or a read API. The SQS message is thin by design, so the body is re-read locally; coupling is contained by a KG-owned DTO + a published-language read contract.
 - **Pipeline → one enrichment core (two drivers); `EmbedNodes` and `MergeDuplicateNodes` split out** (§4), not a single fat job and not fully fragmented per-stage jobs.
 - **Extraction → hybrid, vocabulary enforced in the gateway** ([extraction](./feature-knowledge-graph-processing-extraction.md)), not LLM-only and not rules-only.
 - **Resolution → conservative hybrid + deferred merge; the decision is a pure domain service** ([resolution](./feature-knowledge-graph-processing-resolution.md)), not synchronous fuzzy merging. Prefers transient fragmentation over irreversible over-merge.
-- **Idempotency → deterministic-`eventId`-anchored ledger, separate from the cursor** ([idempotency](./feature-knowledge-graph-processing-idempotency.md)), not "cursor is enough." Survives non-deterministic extraction; extractor versioning re-processes by design.
+- **Idempotency → deterministic-`eventId`-anchored ledger** ([idempotency](./feature-knowledge-graph-processing-idempotency.md)), not keyed on extractor output. Survives SQS redelivery and non-deterministic extraction; extractor versioning re-processes by design.
 - **`graphId` → a resolution policy/port with a Phase-0 single-graph default** ([idempotency](./feature-knowledge-graph-processing-idempotency.md)). Completes the multi-tenancy decision the domain deferred, behind a swappable port.
 - **No `IdGenerator` port** (§3) — the domain factories mint ids; the app passes only `now`.
 
@@ -134,7 +132,6 @@ packages/server-knowledge/src/
 └─ application/
    ├─ use-cases/
    │  ├─ enrich-events.use-case.ts           # EnrichEvents (SQS push)
-   │  ├─ reconcile-enrichment.use-case.ts    # ReconcileEnrichment (cursor catch-up)
    │  ├─ embed-nodes.use-case.ts             # EmbedNodes
    │  └─ merge-duplicate-nodes.use-case.ts   # MergeDuplicateNodes
    └─ ports/outbound/
@@ -145,17 +142,16 @@ packages/server-knowledge/src/
       ├─ knowledge-graph-edge.repository.ts  # edge repo port
       ├─ node-resolution.index.ts            # NodeResolutionIndex
       ├─ graph-resolution.policy.ts          # GraphResolution
-      ├─ checkpoint.store.ts                 # CheckpointStore
       ├─ processed-event.ledger.ts           # ProcessedEventLedger
       └─ unit-of-work.ts                     # KG-owned UnitOfWork + KnowledgeContext
 
 packages/server-knowledge-infra/src/         # adapters (NOT built here)
-├─ persistence/                              #   *.repository.pg.ts, checkpoint/ledger tables, pgvector resolution index, UoW
+├─ persistence/                              #   *.repository.pg.ts, ledger table, pgvector resolution index, UoW
 ├─ gateways/                                 #   LLM extractor, embedder
 └─ read/                                     #   event-table reader implementing EventSourceReader
 
 apps/server-knowledge-worker/src/
-├─ jobs/                                      # SQS consumer + jittered loops (enrich / reconcile / embed / merge)
+├─ jobs/                                      # SQS consumer (enrich) + jittered loops (embed / merge)
 └─ composition/                              # DI: wire use cases ← infra adapters
 ```
 
@@ -167,6 +163,6 @@ apps/server-knowledge-worker/src/
 
 - This is a **pure application layer over an already-decided domain**: it reads the event payloads the domain refuses to dereference, and orchestrates `create`/`attachEvents`/`reinforce`/`relate` — adding no new domain rules. Timestamps enter via the `Clock`; ids are minted inside the domain factories.
 - It resolves the **one judgment call the domain left open** — `graphId` per event — behind a swappable policy, and honors the **one hard boundary the domain set** — provenance is `eventIds`, never a `DERIVED_FROM` edge.
-- Idempotency is anchored on the deterministic **event id** (ledger), kept distinct from **progress** (cursor), so the pipeline is safe under at-least-once delivery _and_ non-deterministic extraction.
-- Everything impure — trigger, event source, extractor, embedder, store — is **behind a port**, so the trigger graduation (push ⇄ reconcile), the integration graduation (shared-DB → published payload), and the store graduations of `database-tradeoffs.md` all stay **adapter-local**. The application core never moves.
+- Idempotency is anchored on the deterministic **event id** (ledger), so the pipeline is safe under at-least-once SQS delivery _and_ non-deterministic extraction.
+- Everything impure — trigger, event source, extractor, embedder, store — is **behind a port**, so a future trigger graduation (adding a reconciler over the same use case), the integration graduation (shared-DB → published payload), and the store graduations of `database-tradeoffs.md` all stay **adapter-local**. The application core never moves.
 </content>

--- a/docs/thoughts/feature-knowledge-graph-processing.md
+++ b/docs/thoughts/feature-knowledge-graph-processing.md
@@ -1,13 +1,15 @@
 # RecallOS — Knowledge Graph Processing (Application Layer)
 
-Designs the **application layer** of the knowledge-graph context: the use cases, ports, and orchestration that take raw **event entries** from the ingest log and **enrich the graph** out of them — extract → resolve → upsert nodes → embed → relate. This is the **"enrich → relate"** stage of the product pipeline (`capture → enrich → relate → recall`), driven by the cron `Worker` (`apps/worker`, a driving adapter — [`project-structure.md`](./project-structure.md) §6).
+Designs the **application layer** of the knowledge context (`@repo/server-knowledge`): the use cases, ports, and orchestration that take raw **event entries** from the ingest log and **enrich the graph** out of them — extract → resolve → upsert nodes → embed → relate. This is the **"enrich → relate"** stage of the product pipeline (`capture → enrich → relate → recall`), driven by the enricher runtime (`apps/server-knowledge-worker`, a driving adapter — [`project-structure.md`](./project-structure.md) §6).
 
 It is the discovery that two siblings explicitly deferred to "later":
 
 - [`feature-knowledge-graph.md`](./feature-knowledge-graph.md) designed the **domain** of this context (Approach A — node/edge as independent aggregate roots, a thin graph root, the `GraphRelation` domain service, closed `NodeType`/`RelationshipType` vocabularies, `DUPLICATE_OF` + `mergeNodes` for entity resolution) and ended with _"`application/` — use cases + ports — separate discovery."_ **This is that discovery.**
-- [`feature-event-ingestion.md`](./feature-event-ingestion.md) §7 named the seam that _kicks off_ enrichment — a future `EventRecorded` domain event published via an `EventPublisher` port — calling it _"a separate context, a separate discovery."_ This doc consumes that seam (and copes with the fact that it isn't built yet, §3).
+- [`feature-event-ingestion.md`](./feature-event-ingestion.md) §7 named the seam that _kicks off_ enrichment. That seam has since been designed in [`feature-event-publication.md`](./feature-event-publication.md) and **built** (outbox → SQS, see §1 below) — so this layer now consumes a seam that exists, not one it has to cope around.
 
-Scope is the **pure application core**: inbound (driving) ports + their use-case implementations, and outbound (driven) port interfaces. Adapters (the LLM extractor, the embedder, the Postgres repositories, the `pgvector` resolution index, the event-log reader, the checkpoint/ledger tables) are named as seams in §15 but **not built** — they live in `@repo/knowledge-graph-infra`. Like its siblings, this is a **design contract the package should converge toward**, not code on disk.
+Scope is the **pure application core**: inbound (driving) ports + their use-case implementations, and outbound (driven) port interfaces. Adapters (the LLM extractor, the embedder, the Postgres repositories, the `pgvector` resolution index, the event-log reader, the checkpoint/ledger tables) are named as seams but **not built** — they live in `@repo/server-knowledge-infra`.
+
+> **State of the code (2026-05).** The KG **domain** is on disk: `KnowledgeGraph`, `KnowledgeGraphNode`, `KnowledgeGraphEdge` aggregates, their value objects, the closed `NodeType`/`RelationshipType` vocabularies, and the `Invalid*` errors — currently exposing **`create`/`restore` only**. The mutators and services this layer orchestrates (`attachEvents`, `assignEmbedding`, `reviseBody`, `reinforce`, `GraphRelation.relate`, `EntityResolution.classify`, `mergeNodes`, `KnowledgeGraph.accepts`) are the domain contract from `feature-knowledge-graph.md` and are **not all implemented yet**. The KG **application layer** (everything below) and `@repo/server-knowledge-infra` are still empty. So this remains **a design contract the package should converge toward**, not code on disk.
 
 ---
 
@@ -21,9 +23,9 @@ capture  →  enrich  →  relate  →  recall
             └────── this doc ──────┘
 ```
 
-`Service` appends opaque events to an append-only log; this application layer **drains that log and distills the graph from it** — entities become **nodes** (with embeddings), assertions become **typed edges** — so that `recall` can later traverse trustworthy, time-aware relationships.
+`Service` (`apps/server-api-service`) appends opaque events to an append-only log and, in the same transaction, writes an **outbox** row; a relay (`apps/server-outbox-worker`) forwards each as a thin SQS message ([`feature-event-publication.md`](./feature-event-publication.md), ADR [`20260524-outbox-sqs-event-publication`](../../decision-records/server/20260524-outbox-sqs-event-publication.md)). This application layer **drains that stream and distills the graph from it** — entities become **nodes** (with embeddings), assertions become **typed edges** — so that `recall` can later traverse trustworthy, time-aware relationships.
 
-> **The framing that shapes everything below.** The _domain_ model is deliberately blind to event payloads: a node references the events it was derived from **by `EventId` only** and _"never dereferences them"_ (`feature-knowledge-graph.md` §2/§4.1). But **enrichment cannot be blind** — to extract entities and relationships it must read the event's opaque **`body`**, its routing **`tags`**, and its **`occurredAt`**. So the _application_ layer needs a cross-context **event-read port** that returns payloads, while the _domain_ keeps storing only `EventId`s as provenance. The read port is an **anti-corruption layer**: it returns a knowledge-graph-owned DTO and **never imports the ingestion `Event` aggregate**. Holding this line — payload-reading in the app, id-only provenance in the domain — is the spine of the design.
+> **The framing that shapes everything below.** The _domain_ model is deliberately blind to event payloads: a node references the events it was derived from **by `EventId` only** and _"never dereferences them"_ (`feature-knowledge-graph.md` §2/§4.1). But **enrichment cannot be blind** — to extract entities and relationships it must read the event's opaque **`body`**, its routing **`tags`**, and its **`occurredAt`**. The published SQS message is deliberately **thin** (`eventId`, timestamps, `tags` — never the `body`; `feature-event-publication.md` §3), so the app layer **re-reads the body** through a cross-context **event-read port**. The read port is an **anti-corruption layer**: it returns a knowledge-owned DTO and **never imports the ingestion `Event` aggregate**. Holding this line — payload-reading in the app, id-only provenance in the domain — is the spine of the design.
 
 This doc is **write-side only.** The recall/read path (`RelationshipGraph` traversal, ranking, GraphRAG) is a separate discovery; the `RelationshipGraph` port named in the domain doc is _not_ exercised here.
 
@@ -36,77 +38,31 @@ This doc is **write-side only.** The recall/read path (`RelationshipGraph` trave
 | **Event entry**             | A read DTO `{ id, occurredAt, tags, body }` returned by the event-read port. The app's view of a raw log item — distinct from the domain's id-only `EventId`. |
 | **Candidate**               | A _proposed_ entity or relationship emitted by the extractor from one event entry, **before** resolution. Not yet a node/edge.                                |
 | **Resolution**              | Deciding whether a candidate entity **is** an existing node, is **new**, or is **ambiguous** (defer). Produces a `NodeId`.                                    |
-| **Enrichment run**          | One execution of the `EnrichEvents` use case over a bounded page of events.                                                                                   |
-| **Checkpoint / cursor**     | The high-water mark of _progress_ through the log — "events up to here have been pulled." Keyed on `recordedAt`.                                              |
-| **Processed-events ledger** | The record of _effect_ — "this `eventId` was processed by this extractor version." The idempotency guard. Distinct from the cursor (§9).                      |
+| **Enrichment run**          | One execution of the enrichment core over a bounded set of event entries (one SQS batch, or one reconcile page).                                              |
+| **Checkpoint / cursor**     | The high-water mark of _progress_ through the log — "events up to here have been pulled." Keyed on `recordedAt`. Backs the SQS push as a catch-up reconciler. |
+| **Processed-events ledger** | The record of _effect_ — "this `eventId` was processed by this extractor version." The idempotency guard. Distinct from the cursor.                           |
 | **factHash**                | A content hash of `(eventId, normalized-fact)` used to detect "same fact, already asserted" and skip redundant work.                                          |
-| **Extractor version**       | A monotonically-bumped tag for the extraction logic/prompt/model. Reprocessing under a new version is legitimate (§9).                                        |
+| **Extractor version**       | A monotonically-bumped tag for the extraction logic/prompt/model. Reprocessing under a new version is legitimate.                                             |
 
-> **Naming caution (three things called "event").** _Event entry_ = a raw item in the ingest log (the thing we read). _Domain event_ = the kernel pub/sub building block (`NodeCreated`, `NodesRelated`, …) recorded on aggregates and published after commit. _`EventRecorded`_ = the specific (future) domain event ingestion will raise to notify us a fact landed (§3). They share a word, not a concept.
-
----
-
-## 3. Central decision — how this context consumes events
-
-Enrichment must be _triggered_ and must _know which events are new_. Two shapes:
-
-### Approach A — cron batch-pull with a cursor
-
-The `Worker`'s cron fires `EnrichEvents`; the use case **pulls** a bounded page of events from the read port (`WHERE recordedAt > cursor ORDER BY recordedAt, id`), processes them, and advances the cursor. Triggering (cron) and progress (cursor) are owned here.
-
-### Approach B — event-driven queue push
-
-Ingestion publishes `EventRecorded` to a queue; a `Worker` consumer drives `EnrichEvents` per event (or per micro-batch) in near-real-time.
-
-|                             | Approach A — pull + cursor                                                                       | Approach B — queue push                                                         |
-| --------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| **Buildable today**         | **Yes** — only needs to read the existing `events` table.                                        | **No** — depends on an upstream seam that doesn't exist yet (see below).        |
-| **Latency**                 | Minutes (cron cadence).                                                                          | Seconds.                                                                        |
-| **LLM/embedding economics** | **Batches naturally** — a page of events amortizes model calls; bounded page = bounded cost/run. | Per-event calls unless the consumer re-batches; worse unit economics.           |
-| **Infra**                   | A cron trigger + a cursor row. **Minimal.**                                                      | A queue/bus, a consumer, DLQ, visibility-timeout tuning. **More moving parts.** |
-| **Back-pressure**           | Trivial — non-overlapping cron + bounded page (§10).                                             | Needs explicit consumer concurrency/back-pressure control.                      |
-| **Ordering**                | We sort each page deterministically (§10).                                                       | At-least-once, out-of-order delivery to reason about.                           |
-
-**The constraint that decides it:** the ingestion `Event` aggregate as designed has **no `EventRecorded` domain event and no `EventPublisher`** — `feature-event-ingestion.md` §7 lists them as _future_ work (_"when capture later needs to notify the Worker…"_). **So Approach B literally cannot be built until ingestion adds that seam.** That isn't a reason to prefer A on its own, but combined with A's better batch economics and minimal infra for a small team on one Aurora cluster, it's decisive.
-
-**Recommendation: Approach A for Phase 0.** Crucially, **shape the inbound port so a queue consumer can drive it later without touching the app layer** — `EnrichEvents.execute({ batchSize })` is agnostic to _who_ calls it. When ingestion grows the `EventRecorded`/`EventPublisher` seam, a queue-driving adapter in `apps/worker/src/jobs/` becomes a new driving adapter over the _same_ use case; the cursor degrades to a safety-net reconciler. Graduation is an adapter, not a rewrite.
+> **Naming caution (three things called "event").** _Event entry_ = a raw item in the ingest log (the thing we read). _Domain event_ = the kernel pub/sub building block (`NodeCreated`, `NodesRelated`, …) recorded on aggregates. _`EventRecorded`_ = the specific domain event ingestion raises (now built) to announce a fact landed. They share a word, not a concept.
 
 ---
 
-## 4. Central decision — cross-context integration (context mapping)
-
-Approach A still has to _read_ events that belong to the **ingestion** bounded context. Three integration styles (DDD context-mapping terms in parentheses):
-
-|                     | Shared-DB read via ACL port _(Shared Database)_                                                                                       | Payload-in-event _(Published Language)_                                                          | Sync read API _(Open-Host / Customer-Supplier)_                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| **How**             | A `knowledge-graph-infra` adapter `SELECT`s the `events` table directly, behind our `EventSourceReader` port, mapping rows → our DTO. | `EventRecorded` carries the full `{occurredAt, tags, body}`; we consume the payload off the bus. | We call an ingestion HTTP/RPC endpoint to fetch event payloads. |
-| **Buildable now**   | **Yes** (one Aurora cluster).                                                                                                         | No (no publisher seam yet — §3).                                                                 | No (no such endpoint; both runtimes already share the DB).      |
-| **Coupling**        | **Highest** — two contexts share a table. Mitigated by the ACL (below).                                                               | Low — contexts share only a message contract.                                                    | Low — contexts share only an API contract.                      |
-| **Latency / cost**  | One local query per page.                                                                                                             | Bus delivery; payload duplicated into messages.                                                  | Network hop + ingestion serving load.                           |
-| **Fit for Phase 0** | **Best** — pragmatic on a consolidated DB.                                                                                            | Premature (infra we don't have).                                                                 | Pointless indirection (same DB, two of our own runtimes).       |
-
-**Recommendation: shared-DB read behind an anti-corruption `EventSourceReader` port.** Name the coupling honestly — it _is_ the most-coupled option — and contain it:
-
-1. The adapter returns a **knowledge-graph-owned DTO** (`EventEntry`, §13), **never** the ingestion `Event` aggregate. The KG package does not depend on `@repo/ingestion`.
-2. Treat the columns we read — `{ id, occurredAt, tags, body }` — as a **published-language read contract**. As long as ingestion preserves those, our adapter is stable.
-
-Because the contract is the port, graduating to payload-in-event (once the upstream publisher exists) or to a read API is a **new adapter for the same port** — zero app-layer change. This is exactly the "keep it behind an interface, graduate by evidence" discipline of `database-tradeoffs.md` and `project-structure.md`.
-
----
-
-## 5. Building blocks reused
+## 3. Building blocks reused
 
 This layer writes **no new domain types** — it orchestrates existing ones.
 
-- **From the KG domain (`feature-knowledge-graph.md`):** `KnowledgeGraphNode.create / attachEvents / assignEmbedding / reviseBody`; `KnowledgeGraphEdge.create / reinforce`; the pure domain service `GraphRelation.relate(...)`; the thin `KnowledgeGraph.accepts(embedding)` policy; value objects `NodeBody`, `Embedding`, `Confidence`, the ids; and the **closed vocabularies** `NodeType` / `RelationshipType`. The edge-dedup rule — identity is the triple `(fromId, toId, relationship)` per graph, re-assertion **reinforces** — and the provenance-set semantics (`eventIds` only grow) are the backbone of idempotency (§9).
-- **From `@repo/kernel`:** `Result<T>` (use-case outcomes are values, not throws), `Id`, `Clock`, `DomainEvent`, `DomainError`.
-- **From `@repo/platform`:** the **unit-of-work** (atomic multi-aggregate writes while still one Postgres — §10), the **eventBus** (publish-after-commit), the pg pool, the `pino` logger, `zod` config.
+- **From the KG domain (`@repo/server-knowledge`, `feature-knowledge-graph.md`):** `KnowledgeGraphNode.create / attachEvents / assignEmbedding / reviseBody`; `KnowledgeGraphEdge.create / reinforce`; the pure domain service `GraphRelation.relate(...)`; the thin `KnowledgeGraph.accepts(embedding)` policy; value objects `NodeBody`, `Embedding`, `Confidence`, the ids; and the **closed vocabularies** `NodeType` / `RelationshipType`. The edge-dedup rule — identity is the triple `(fromId, toId, relationship)` per graph, re-assertion **reinforces** — and the provenance-set semantics (`eventIds`/`sourceEventIds` only grow) are the backbone of idempotency ([idempotency sub-doc](./feature-knowledge-graph-processing-idempotency.md)).
+- **From `@repo/server-kernel`:** `Result<T>` (use-case outcomes are values, not throws — ADR [`20260523-result-vs-throw`](../../decision-records/server/20260523-result-vs-throw-hexagonal-backend.md)), `Id` (mints UUID v7), `Clock`, `DomainEvent`, `DomainError`.
+- **From `@repo/server-platform`:** the `pino` logger and `zod` config. (The pg pool / event bus are still "to come"; the **unit-of-work is a context-owned outbound port**, mirroring `@repo/server-ingestion` — see §4 and the [idempotency sub-doc](./feature-knowledge-graph-processing-idempotency.md).)
 
-The domain stays pure precisely _because_ this layer owns the impure inputs it needs: **ids and timestamps are generated here** (via `IdGenerator` and `Clock` ports) and passed _into_ the domain factories, as the domain doc requires.
+> **Ids are minted inside the domain factories, not by an app-layer port.** `KnowledgeGraphNode.create` / `KnowledgeGraphEdge.create` already call `NodeId.create()` / `EdgeId.create()` (kernel UUID v7) internally and take only `now: Date`. So this layer passes the `Clock`'s `now` into the factories and lets the domain mint the id — there is **no `IdGenerator` port**. (An earlier draft of this doc proposed one; the built domain made it unnecessary.)
+
+The domain stays pure precisely _because_ this layer owns the impure inputs it needs: **timestamps are generated here** (via the `Clock` port) and passed _into_ the domain factories.
 
 ---
 
-## 6. Pipeline shape & use-case decomposition
+## 4. Pipeline shape & use-case decomposition
 
 Enrichment is a multi-stage pipeline:
 
@@ -116,345 +72,69 @@ read events → extract candidates → resolve to nodes → upsert nodes → rel
                                                       embed node bodies
 ```
 
-The decision is **where to cut it into use cases**. Recommendation: **one cohesive write use case, with embedding and merging split out.**
+**One cohesive write core, two drivers, embedding and merging split out.**
 
-| Use case (inbound port)   | Responsibility                                                                                                                                   | Driven by                                          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| **`EnrichEvents`**        | The hot path: read a page → extract → resolve → upsert nodes → relate edges → advance cursor → publish domain events. One transactional run.     | Cron (today); queue later (§3).                    |
-| **`EmbedNodes`**          | Assign/refresh embeddings for nodes that need one. Calls the embedding gateway, then `node.assignEmbedding(...)`.                                | `NodeCreated` / body-revision / model-drift (§12). |
-| **`MergeDuplicateNodes`** | Drain `DUPLICATE_OF` edges: fold provenance into the survivor (`attachEvents`) and re-point incident edges. Reuses the domain's merge semantics. | Cron (async reconciler).                           |
+| Use case (inbound port)   | Responsibility                                                                                                                          | Driven by                                                                |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **`EnrichEvents`**        | The hot path: given event ids, read bodies → extract → resolve → upsert nodes → relate edges → record ledger. One transactional run.   | **SQS push** (`apps/server-knowledge-worker` consumer).                  |
+| **`ReconcileEnrichment`** | The safety net: pull a bounded page `WHERE recordedAt > cursor`, run the **same** core, advance the cursor.                            | **Jittered catch-up loop** (same app, longer interval — ADR `20260529`). |
+| **`EmbedNodes`**          | Assign/refresh embeddings for nodes that need one. Calls the embedding gateway, then `node.assignEmbedding(...)`.                       | Jittered loop scanning nodes needing embedding (resolution sub-doc).     |
+| **`MergeDuplicateNodes`** | Drain `DUPLICATE_OF` edges: fold provenance into the survivor (`attachEvents`) and re-point incident edges. Reuses the merge semantics. | Jittered reconciler loop.                                                |
 
-**Why split embedding out** (rather than embedding inline in `EnrichEvents`):
+`EnrichEvents` and `ReconcileEnrichment` share one internal enrichment routine and the same **processed-events ledger** guard, so a message processed by the push path and later re-seen by the reconcile poll is a no-op. The trigger model — in-process **sleep + jitter** loops, not cron — is decided in ADR [`20260529-in-process-sleep-jitter-worker-trigger`](../../decision-records/server/20260529-in-process-sleep-jitter-worker-trigger.md); SQS push is the hot path, the cursor poll backs it up.
 
-|                        | Embedding split into `EmbedNodes`                                                                                                                                                                            | Embedding inline in `EnrichEvents`                         |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| **Domain signal**      | The domain _already_ makes embedding **optional at birth** and assigns it later via `assignEmbedding`, recording a _separate_ `NodeEmbedded` event. The model is telling us it's a distinct lifecycle phase. | Fights the domain — forces a node to be born embedded.     |
-| **Failure isolation**  | An embedding-API outage **does not block graph construction**; nodes are born `embedding: null` by design and get embedded on the next `EmbedNodes` run.                                                     | An embedding outage wedges the whole enrichment run.       |
-| **Cost / rate limits** | The most expensive, most rate-limited call is isolated and independently retriable/batchable.                                                                                                                | Couples graph mutation throughput to embedding throughput. |
-| **Reuse**              | The same job handles **re-embedding** on body revision / model change (§12).                                                                                                                                 | Re-embedding needs separate plumbing anyway.               |
+**Why split embedding out** (rather than embedding inline in `EnrichEvents`): the domain makes embedding **optional at birth** (`create` always sets `embedding: null`) and assigns it later via `assignEmbedding`, recording a separate `NodeEmbedded` event — a distinct lifecycle phase. An embedding-API outage then **does not block graph construction**, the most expensive/rate-limited call is isolated and independently retriable, and the same job handles **re-embedding** on body revision / model change. Full reasoning in the [resolution & embedding sub-doc](./feature-knowledge-graph-processing-resolution.md).
 
-**Why _not_ split further** (separate extract / resolve / relate jobs) in Phase 0: it buys decoupling we don't need, multiplies the idempotency surface, and breaks the natural per-event atomicity that makes a run easy to reason about. `MergeDuplicateNodes` is split out only because it is inherently _asynchronous and cross-aggregate_ (it rewrites edges of two nodes at once).
+`MergeDuplicateNodes` is split out only because it is inherently _asynchronous and cross-aggregate_ (it rewrites edges of two nodes at once). Splitting extract/resolve/relate into separate jobs is **not** done in Phase 0: it buys decoupling we don't need, multiplies the idempotency surface, and breaks the natural per-event atomicity that makes a run easy to reason about.
 
 ---
 
-## 7. Extraction — opaque body → typed candidates
+## 5. The four sub-documents
 
-The extractor turns an event entry's **opaque** body into **candidates** already typed to the closed vocabulary. It is pure I/O (a model/parse call), so it is an **outbound gateway port** (`EntityExtractorGateway`); the use case never embeds extraction logic.
+The depth lives in four focused sub-docs. Read in pipeline order:
 
-**Recommendation: hybrid extraction, routed on `tags`.** `tags` is explicitly _"what the Worker routes on"_ (ingestion §2):
-
-- **Deterministic rules** for known _structured_ sources (a Slack message, a GitHub PR, a calendar invite). Cheap, exact, **deterministic** — and the only reliable source of _structural_ relationships.
-- **LLM structured-output** for _free-text_ bodies, constrained to emit only `NodeType`/`RelationshipType` members.
-
-|                                | Rules (structured sources) | LLM (free-text)        | Hybrid (recommended)                |
-| ------------------------------ | -------------------------- | ---------------------- | ----------------------------------- |
-| **Accuracy on known shapes**   | **High**                   | Medium                 | **High**                            |
-| **Coverage of unknown shapes** | Low                        | **High**               | **High**                            |
-| **Cost / latency**             | **Negligible**             | High                   | Pay LLM cost **only** for free-text |
-| **Determinism / idempotency**  | **Deterministic**          | Non-deterministic (§9) | Deterministic where it matters most |
-
-> **Vocabulary is enforced in the gateway adapter, not the orchestrator.** The gateway's _output type_ is already `NodeType`/`RelationshipType`; mapping an un-classifiable relation to `RELATED_TO` (or dropping it) happens **inside the adapter** (e.g. via a structured-output schema/grammar). If the gateway returned free strings and the use case mapped them, vocabulary governance would leak into the application layer. The closed vocabulary is the domain's contract; the adapter honors it.
-
-**Where the typed relationships actually come from** — a mapping the doc makes explicit so adapters are consistent:
-
-| Source signal                       | Candidate relationship               | Notes                                      |
-| ----------------------------------- | ------------------------------------ | ------------------------------------------ |
-| message `author` field              | `AUTHORED_BY` / `SENT_BY`            | Deterministic, from structured metadata.   |
-| thread `parent`/`in_reply_to`       | `REPLIES_TO`                         | Deterministic.                             |
-| document → its section/attachment   | `PART_OF`                            | Deterministic structural composition.      |
-| task `assignee`                     | `ASSIGNED_TO`                        | Deterministic.                             |
-| free-text naming a person/org/topic | `MENTIONS`, `INVOLVES`, `RELATED_TO` | LLM; default to the weakest accurate type. |
-| explicit "see also" / citation      | `REFERENCES`                         | Either, depending on source.               |
-
-> **Do not conflate `DERIVED_FROM` with `eventIds` provenance.** A node's link back to the **events** that justify it is the node's `eventIds` set — **not** an edge. `DERIVED_FROM` is a **node→node** lineage edge (e.g. a summary node derived from a document node). The extractor must keep these separate; emitting `DERIVED_FROM` edges to represent event provenance would double-model the data and corrupt traversal.
+1. **[Event consumption & cross-context integration](./feature-knowledge-graph-processing-event-consumption.md)** — how enrichment is triggered (SQS push + cursor reconcile) and how it reads events that belong to the ingestion context behind an anti-corruption `EventSourceReader` port. Ports: `EventSourceReader`, `CheckpointStore`; inbound `EnrichEvents` / `ReconcileEnrichment`; the enrichment orchestration.
+2. **[Extraction](./feature-knowledge-graph-processing-extraction.md)** — opaque `body` → candidates already typed to the closed vocabulary; hybrid rules + LLM routed on `tags`; vocabulary enforced in the gateway; the source-signal → relationship mapping; `DERIVED_FROM` vs `eventIds`. Port: `EntityExtractorGateway`.
+3. **[Entity resolution & embedding](./feature-knowledge-graph-processing-resolution.md)** — deciding a candidate **is** an existing node (deterministic key → vector ANN → defer); the pure `EntityResolution.classify` decision; `EmbedNodes` triggers; node-body canonicalization. Ports: `NodeResolutionIndex`, `EmbeddingGateway`, the node/edge repositories.
+4. **[Idempotency, consistency & multi-tenancy](./feature-knowledge-graph-processing-idempotency.md)** — at-least-once safety (ledger vs cursor, `factHash`, extractor versioning); the transaction boundary (context-owned unit-of-work); ordering / poison events / back-pressure; resolving a `graphId` per event. Ports: `ProcessedEventLedger`, `GraphResolution`, `UnitOfWork`.
 
 ---
 
-## 8. Entity resolution / dedup
-
-The hardest stage: deciding a candidate entity **is** an existing node. **Recommendation: a conservative hybrid with deferred merge**, and a clean **split of responsibility** between an I/O port and a pure decision.
-
-1. **Deterministic natural key first.** Normalize `(type, key)` (e.g. `PERSON` + canonical email/handle) and look it up. Exact, cheap, deterministic.
-2. **Vector ANN second.** If no key hit, embed the candidate body and ask the resolution index for similar same-type nodes above a threshold.
-3. **Defer the hard cases.** If matches are ambiguous (near-threshold, multiple plausible), **do not guess in the hot path** — create the node _and_ record a `DUPLICATE_OF` candidate that `MergeDuplicateNodes` reconciles later (reusing the domain's `mergeNodes`). Provenance is never lost, so deferring is safe.
-
-**Port vs domain service — split by responsibility** (mirroring how `GraphRelation.relate` takes already-loaded aggregates):
-
-- The **I/O** — natural-key lookup, ANN search — is an outbound port (`NodeResolutionIndex` + repo lookups).
-- The **decision** — _"this candidate is `Resolved(nodeId)` / `New` / `Ambiguous`"_ — is a **pure domain service** `EntityResolution.classify(candidate, matches)`, operating on already-fetched matches. This keeps the _threshold policy_ pure and unit-testable instead of buried in an adapter.
-
-| Strategy                             | Pro                                                                                   | Con                                                                      |
-| ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Deterministic key only               | Fast, deterministic, no model cost                                                    | Misses fuzzy duplicates ("Alice" vs "Alice Smith") → fragmentation       |
-| Vector similarity only               | Catches fuzzy duplicates                                                              | Threshold tuning; risk of **over-merging** distinct entities; model cost |
-| LLM canonicalization                 | Highest recall                                                                        | Cost, latency, non-determinism, hardest to make idempotent               |
-| **Hybrid + deferred merge (chosen)** | Deterministic where possible, fuzzy where needed, **never over-merges synchronously** | Two passes; the merge backlog must be drained                            |
-
-The bias is **conservative**: prefer transient fragmentation (fixable by a later merge) over irreversible over-merging in the hot path.
-
----
-
-## 9. Idempotency & delivery semantics
-
-Processing is **at-least-once** (a run can crash after writing but before advancing the cursor; a redelivered queue message can repeat). Therefore **writes must be idempotent**.
-
-The domain _gives_ us idempotent writes — **but only if resolution is stable**:
-
-- Re-asserting an edge triple `(from, to, relationship)` **reinforces** instead of duplicating.
-- `attachEvents` unions provenance — re-adding an `eventId` is a no-op.
-
-The threat: **LLM extraction is non-deterministic**, so the _same_ event reprocessed can yield slightly different candidates, which could resolve to _different_ nodes and break that stability.
-
-**Recommendation: anchor idempotency on the deterministic `eventId`, not on extractor output. Keep two distinct mechanisms:**
-
-| Mechanism                   | Question it answers                          | Key                                                        | Why separate                                                                       |
-| --------------------------- | -------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Checkpoint / cursor**     | "How far have we _pulled_?"                  | `recordedAt` high-water mark                               | Progress only. Append-only log ⇒ monotonic, safe.                                  |
-| **Processed-events ledger** | "Was this event's _effect_ already applied?" | `(eventId, extractorVersion) → status, factHash, attempts` | **Exactly-once effect.** Skip an already-processed event regardless of LLM jitter. |
-
-Layered guards beneath the ledger: **deterministic candidate keys** (normalized name+type) so that even a re-extraction resolves to the _same_ node; and **`factHash`** of `(eventId, normalized-fact)` to skip re-asserting a fact already recorded (avoids confidence churn).
-
-**Extractor versioning is a feature, not a bug.** Bumping `extractorVersion` makes the ledger _miss_, so events are legitimately reprocessed under the better extractor — provenance grows, edges reinforce, nothing duplicates. That is exactly the desired "the graph improves as the extractor improves" behavior.
-
----
-
-## 10. Cross-cutting consistency & failure
-
-- **Transaction boundary.** Per Approach A of the domain, node and edge are separate aggregates. A run wraps its writes — **nodes + edges + ledger rows + checkpoint** — in the platform **unit-of-work**, so a page commits atomically while we are still on one Postgres. When the graph store later splits out (Neptune), this degrades to _accepted eventual consistency_ (domain §8) — the "no dangling edge / no duplicate edge" guarantees are also backed by a DB FK + unique constraint, so a race can't corrupt the store.
-- **Ordering tension — pull by `recordedAt`, relate by `occurredAt`.** We _checkpoint_ on `recordedAt` (monotonic capture order — safe progress for an append-only log). But an edge's **`observedAt` must be the source event's `occurredAt`**, and `reinforce` keeps the _latest_ `observedAt`. Late-arriving events mean `recordedAt` order ≠ `occurredAt` order. So: **pull/checkpoint by `recordedAt`, but sort the in-memory page by `occurredAt` before the relate step.** Mapping is explicit: `edge.observedAt = entry.occurredAt`.
-- **Poison events.** A body that can't be parsed/extracted must **not wedge the cursor**. Record it in the ledger as `failed` with an attempt count; after N attempts it's parked (dead-lettered), the cursor moves past it, and a human/alert handles the backlog. One bad event never blocks the pipeline.
-- **Back-pressure & cost.** The cost center is extraction + embedding. Controls: a **bounded page size**, **non-overlapping cron** (a run won't start if one is in flight), a **per-run budget** (max events / max model calls), and the fact that batch-pull (§3) lets the extractor/embedder **batch** calls. These are stated as non-functional constraints, not afterthoughts.
-
----
-
-## 11. `graphId` resolution / multi-tenancy during enrichment
-
-**The gap the domain deferred but this layer cannot.** Every `KnowledgeGraphNode.create` and `KnowledgeGraphEdge.create` requires a `graphId`, yet an event entry carries only `tags` + `body`. _Which graph does an event belong to?_ The domain doc **explicitly defers** multi-tenancy/scope (§10) while namespacing everything by `graphId`. The application layer **must** resolve a concrete `graphId` for every event just to call the domain at all — so it resolves the tension the domain left open (this is _completing_ the deferred decision, **not** contradicting it).
-
-**Recommendation: a `GraphResolution` policy/port** mapping `event.tags` (e.g. an `org` / `workspace` tag) → `KnowledgeGraphId`, with a **Phase-0 default of a single well-known graph**. Keeping it a port means that when real multi-tenancy/isolation arrives (its own discovery), it's a policy swap — the enrichment use cases don't change. Resolution happens **once per event**, before extraction, and the resolved `graphId` flows into every node/edge created from that event.
-
----
-
-## 12. Re-embedding & body canonicalization
-
-**`EmbedNodes` triggers** — embedding is not a one-shot at birth:
-
-1. **`NodeCreated`** — a new node has `embedding: null`; embed it.
-2. **Body revised** — `reviseBody` changes the canonical text, so the existing embedding is **stale**; re-embed.
-3. **Model drift** — a node whose embedding model ≠ the graph's policy model (`KnowledgeGraph.accepts` returns false) must be **re-embedded** to satisfy the graph-wide embedding policy.
-
-**Node body canonicalization is a real decision, not a detail.** The `NodeBody` text drives _both_ the embedding _and_ the natural key for resolution (§8) — so it silently governs over/under-merge. ("Alice", "alice@corp", "Alice Smith" → one node or three?) **Recommendation: a conservative Phase-0 canonicalization policy** at the extractor/resolution boundary (trim, case-fold, prefer a stable identifier like an email/handle as the key when present; keep a human-readable display body). Make it explicit so fragmentation is a tuning knob, not an accident.
-
----
-
-## 13. Port & use-case sketches
-
-Names follow `project-structure.md` §9 (`*.use-case.ts` for app service + inbound port, `*.repository.ts` for outbound port interfaces, gateways for external systems). All outbound types are **interfaces**; implementations live in `@repo/knowledge-graph-infra`.
-
-### Inbound (driving) ports
-
-```ts
-// enrich-events.use-case.ts
-export interface EnrichmentReport {
-  pulled: number;
-  processed: number;
-  skipped: number;
-  failed: number;
-  nodesUpserted: number;
-  edgesWritten: number;
-  cursor: Checkpoint;
-}
-export interface EnrichEvents {
-  // driving port
-  execute(input: { batchSize: number }): Promise<Result<EnrichmentReport>>;
-}
-
-// embed-nodes.use-case.ts
-export interface EmbedNodes {
-  // driving port
-  execute(input: { nodeIds?: NodeId[]; limit: number }): Promise<Result<void>>;
-}
-
-// merge-duplicate-nodes.use-case.ts
-export interface MergeDuplicateNodes {
-  // driving port
-  execute(input: { limit: number }): Promise<Result<void>>;
-}
-```
-
-### Outbound (driven) ports
-
-```ts
-// event-source.reader.ts — anti-corruption read into the ingestion log
-export interface EventEntry {
-  // KG-owned DTO, NOT ingestion's Event
-  id: EventId;
-  occurredAt: Date;
-  tags: Record<string, string>;
-  body: Record<string, unknown>;
-}
-export interface EventSourceReader {
-  readSince(cursor: Checkpoint, limit: number): Promise<EventEntry[]>; // ORDER BY recordedAt, id
-}
-
-// entity-extractor.gateway.ts — opaque body → candidates already typed to the closed vocab
-export interface CandidateNode {
-  type: NodeType;
-  body: string;
-  naturalKey?: string;
-}
-export interface CandidateEdge {
-  from: CandidateRef;
-  to: CandidateRef;
-  relationship: RelationshipType;
-  confidence: number;
-}
-export interface ExtractionResult {
-  nodes: CandidateNode[];
-  edges: CandidateEdge[];
-  extractorVersion: string;
-}
-export interface EntityExtractorGateway {
-  extract(entry: EventEntry): Promise<ExtractionResult>; // vocabulary enforced in the adapter
-}
-
-// embedding.gateway.ts
-export interface EmbeddingGateway {
-  embed(texts: string[], model: string): Promise<number[][]>; // batched
-}
-
-// knowledge-graph-node.repository.ts
-export interface KnowledgeGraphNodeRepository {
-  findById(id: NodeId): Promise<KnowledgeGraphNode | null>;
-  findByNaturalKey(
-    graphId: KnowledgeGraphId,
-    type: NodeType,
-    key: string,
-  ): Promise<KnowledgeGraphNode | null>;
-  saveMany(nodes: KnowledgeGraphNode[]): Promise<void>;
-}
-
-// knowledge-graph-edge.repository.ts
-export interface KnowledgeGraphEdgeRepository {
-  findByTriple(
-    graphId: KnowledgeGraphId,
-    fromId: NodeId,
-    toId: NodeId,
-    rel: RelationshipType,
-  ): Promise<KnowledgeGraphEdge | null>;
-  saveMany(edges: KnowledgeGraphEdge[]): Promise<void>;
-  repointIncidentEdges(from: NodeId, to: NodeId): Promise<void>; // for merge
-}
-
-// node-resolution.index.ts — ANN over node embeddings (may share the pgvector adapter)
-export interface NodeMatch {
-  id: NodeId;
-  score: number;
-}
-export interface NodeResolutionIndex {
-  findSimilar(
-    graphId: KnowledgeGraphId,
-    type: NodeType,
-    vector: number[],
-    threshold: number,
-    k: number,
-  ): Promise<NodeMatch[]>;
-}
-
-// graph-resolution.policy.ts — §11, the multi-tenancy gap
-export interface GraphResolution {
-  resolve(tags: Record<string, string>): KnowledgeGraphId;
-}
-
-// checkpoint.store.ts — progress
-export interface Checkpoint {
-  recordedAt: Date;
-  lastEventId: EventId;
-}
-export interface CheckpointStore {
-  load(name: string): Promise<Checkpoint>;
-  save(name: string, cursor: Checkpoint): Promise<void>;
-}
-
-// processed-event.ledger.ts — exactly-once effect (§9)
-export type ProcessStatus = "done" | "failed";
-export interface ProcessedEventLedger {
-  seen(eventId: EventId, extractorVersion: string): Promise<boolean>;
-  record(
-    eventId: EventId,
-    extractorVersion: string,
-    status: ProcessStatus,
-    factHash: string,
-    attempts: number,
-  ): Promise<void>;
-}
-
-// from @repo/kernel / @repo/platform
-export interface IdGenerator {
-  nodeId(): NodeId;
-  edgeId(): EdgeId;
-}
-// Clock, EventPublisher (eventBus), UnitOfWork — shared infra
-```
-
-### `EnrichEvents` orchestration (the main flow)
-
-```
-load cursor (CheckpointStore)
-page ← EventSourceReader.readSince(cursor, batchSize)        // ordered by recordedAt
-drop entries already in ProcessedEventLedger (current extractorVersion)
-sort page by occurredAt                                       // §10 — for correct observedAt
-for each entry:
-  graphId ← GraphResolution.resolve(entry.tags)              // §11
-  result  ← EntityExtractorGateway.extract(entry)
-  for each candidate node:
-     matches  ← node repo natural-key lookup + NodeResolutionIndex.findSimilar
-     decision ← EntityResolution.classify(candidate, matches)   // pure domain service
-     New        → KnowledgeGraphNode.create({ id: ids.nodeId(), graphId, …, eventIds:[entry.id], now })
-     Resolved   → node.attachEvents([entry.id], now)
-     Ambiguous  → create + queue a DUPLICATE_OF for MergeDuplicateNodes
-  for each candidate edge:
-     load from/to nodes; existing ← edge repo.findByTriple(...)
-     edge ← GraphRelation.relate({ …, observedAt: entry.occurredAt, existing, now })  // create or reinforce
-in ONE UnitOfWork: node repo.saveMany + edge repo.saveMany + ledger.record(...) + CheckpointStore.save
-after commit: EventPublisher.publish(recorded domain events)  // NodeCreated → triggers EmbedNodes
-```
-
----
-
-## 14. Decisions, alternatives, and deferred work
+## 6. Decisions, alternatives, and deferred work
 
 **Decisions taken (with the rejected alternative):**
 
-- **Consume events → cron batch-pull + cursor** (§3), not queue push. Buildable today (no upstream publisher), better batch economics, minimal infra; the inbound port is shaped so a queue adapter can drive the same use case later.
-- **Integration → shared-DB read behind an ACL port** (§4), not payload-in-event or a read API. Pragmatic on one Aurora cluster; coupling contained by a KG-owned DTO + a published-language read contract.
-- **Pipeline → one `EnrichEvents` use case; `EmbedNodes` and `MergeDuplicateNodes` split out** (§6), not a single fat job and not fully fragmented per-stage jobs. Follows the domain's "embedding is a later phase" signal; isolates expensive/retriable I/O.
-- **Extraction → hybrid, vocabulary enforced in the gateway** (§7), not LLM-only and not rules-only. Deterministic where possible, fuzzy where needed; governance stays in the adapter.
-- **Resolution → conservative hybrid + deferred merge; decision is a pure domain service** (§8), not synchronous fuzzy merging. Prefers transient fragmentation over irreversible over-merge.
-- **Idempotency → deterministic-`eventId`-anchored ledger, separate from the cursor** (§9), not "cursor is enough." Survives non-deterministic extraction; extractor versioning re-processes by design.
-- **`graphId` → a resolution policy/port with a Phase-0 single-graph default** (§11). Completes the multi-tenancy decision the domain deferred, behind a swappable port.
+- **Consume events → SQS push (hot path) + cursor reconcile (safety net)** ([consumption](./feature-knowledge-graph-processing-event-consumption.md)). The original draft chose cron batch-pull because the publisher seam did not exist; it now does (outbox → SQS, ADR `20260524`), so per-event push is the hot path and the cursor poll degrades to a reconciler — exactly the graduation the draft anticipated. Both drive the **same** use-case core; the trigger is a sleep + jitter loop (ADR `20260529`), not cron.
+- **Integration → shared-DB read behind an ACL port** ([consumption](./feature-knowledge-graph-processing-event-consumption.md)), not payload-in-event or a read API. The SQS message is thin by design, so the body is re-read locally; coupling is contained by a KG-owned DTO + a published-language read contract.
+- **Pipeline → one enrichment core (two drivers); `EmbedNodes` and `MergeDuplicateNodes` split out** (§4), not a single fat job and not fully fragmented per-stage jobs.
+- **Extraction → hybrid, vocabulary enforced in the gateway** ([extraction](./feature-knowledge-graph-processing-extraction.md)), not LLM-only and not rules-only.
+- **Resolution → conservative hybrid + deferred merge; the decision is a pure domain service** ([resolution](./feature-knowledge-graph-processing-resolution.md)), not synchronous fuzzy merging. Prefers transient fragmentation over irreversible over-merge.
+- **Idempotency → deterministic-`eventId`-anchored ledger, separate from the cursor** ([idempotency](./feature-knowledge-graph-processing-idempotency.md)), not "cursor is enough." Survives non-deterministic extraction; extractor versioning re-processes by design.
+- **`graphId` → a resolution policy/port with a Phase-0 single-graph default** ([idempotency](./feature-knowledge-graph-processing-idempotency.md)). Completes the multi-tenancy decision the domain deferred, behind a swappable port.
+- **No `IdGenerator` port** (§3) — the domain factories mint ids; the app passes only `now`.
 
 **Deferred on purpose:**
 
-- **Real-time queue path** — awaits ingestion's `EventRecorded`/`EventPublisher` seam (§3).
 - **Advanced entity resolution** — blocking/clustering, LLM canonicalization, active-learning thresholds; Phase 0 is key + ANN + deferred merge.
 - **Full multi-tenancy & isolation** — RLS/scoping enforcement; the policy port reserves the seam.
 - **Recall / read path** — `RelationshipGraph` traversal, ranking, GraphRAG (write-side only here).
-- **Cost/usage metering & autoscaling** — beyond the bounded-page/budget guards of §10.
+- **Richer broker topologies** — SNS→SQS fan-out, Kinesis/MSK replay; each is an adapter swap behind the same seam once a concrete trigger appears (`feature-event-publication.md` §6).
+- **Cost/usage metering & autoscaling** — beyond the bounded-page/budget guards of the idempotency sub-doc.
 
 ---
 
-## 15. Where this lives
+## 7. Where this lives
 
-Per `project-structure.md` §4/§9, the application layer is `application/` inside the pure `@repo/knowledge-graph` package; adapters are in `@repo/knowledge-graph-infra`; wiring is in `apps/worker`.
+Per `project-structure.md` §4/§9, the application layer is `application/` inside the pure `@repo/server-knowledge` package; adapters are in `@repo/server-knowledge-infra`; wiring is in `apps/server-knowledge-worker` (the enricher).
 
 ```
-packages/knowledge-graph/src/
-├─ domain/                                  # designed in feature-knowledge-graph.md
-│  └─ entity-resolution.domain-service.ts   # NEW pure service (classify) — §8
+packages/server-knowledge/src/
+├─ domain/                                  # built (create/restore today) — feature-knowledge-graph.md
+│  └─ entity-resolution.domain-service.ts   # NEW pure service (classify) — resolution sub-doc
 └─ application/
    ├─ use-cases/
-   │  ├─ enrich-events.use-case.ts           # EnrichEvents (inbound port + impl)
+   │  ├─ enrich-events.use-case.ts           # EnrichEvents (SQS push)
+   │  ├─ reconcile-enrichment.use-case.ts    # ReconcileEnrichment (cursor catch-up)
    │  ├─ embed-nodes.use-case.ts             # EmbedNodes
    │  └─ merge-duplicate-nodes.use-case.ts   # MergeDuplicateNodes
    └─ ports/outbound/
@@ -464,27 +144,29 @@ packages/knowledge-graph/src/
       ├─ knowledge-graph-node.repository.ts  # node repo port
       ├─ knowledge-graph-edge.repository.ts  # edge repo port
       ├─ node-resolution.index.ts            # NodeResolutionIndex
-      ├─ graph-resolution.policy.ts          # GraphResolution — §11
+      ├─ graph-resolution.policy.ts          # GraphResolution
       ├─ checkpoint.store.ts                 # CheckpointStore
-      └─ processed-event.ledger.ts           # ProcessedEventLedger
+      ├─ processed-event.ledger.ts           # ProcessedEventLedger
+      └─ unit-of-work.ts                     # KG-owned UnitOfWork + KnowledgeContext
 
-packages/knowledge-graph-infra/src/          # adapters (NOT built here)
-├─ persistence/                              #   *.repository.pg.ts, checkpoint/ledger tables, pgvector resolution index
+packages/server-knowledge-infra/src/         # adapters (NOT built here)
+├─ persistence/                              #   *.repository.pg.ts, checkpoint/ledger tables, pgvector resolution index, UoW
 ├─ gateways/                                 #   LLM extractor, embedder
 └─ read/                                     #   event-table reader implementing EventSourceReader
 
-apps/worker/src/
-├─ jobs/                                      # cron triggers for EnrichEvents / EmbedNodes / MergeDuplicateNodes
+apps/server-knowledge-worker/src/
+├─ jobs/                                      # SQS consumer + jittered loops (enrich / reconcile / embed / merge)
 └─ composition/                              # DI: wire use cases ← infra adapters
 ```
 
-`@repo/knowledge-graph` still lists **only** `@repo/kernel` as a dependency — every line above touching I/O is an interface, satisfied by `-infra`. The dependency rule stays mechanically enforced (`project-structure.md` §8).
+`@repo/server-knowledge` still lists **only** `@repo/server-kernel` (and `zod`) as dependencies — every line above touching I/O is an interface, satisfied by `-infra`. The dependency rule stays mechanically enforced (`project-structure.md` §8; `.claude/rules/server-hexagonal-application-layer.md`).
 
 ---
 
 ## Closing notes
 
-- This is a **pure application layer over an already-decided domain**: it generates the ids/timestamps the domain refuses to invent, reads the event payloads the domain refuses to dereference, and orchestrates `create`/`attachEvents`/`reinforce`/`relate` — adding no new domain rules.
-- It resolves the **one judgment call the domain left open** — `graphId` per event (§11) — behind a swappable policy, and honors the **one hard boundary the domain set** — provenance is `eventIds`, never a `DERIVED_FROM` edge (§7).
-- Idempotency is anchored on the deterministic **event id** (ledger), kept distinct from **progress** (cursor), so the pipeline is safe under at-least-once delivery _and_ non-deterministic extraction (§9).
-- Everything impure — trigger, event source, extractor, embedder, store — is **behind a port**, so the trigger graduation (cron → queue), the integration graduation (shared-DB → published event), and the store graduations of `database-tradeoffs.md` all stay **adapter-local**. The application core never moves.
+- This is a **pure application layer over an already-decided domain**: it reads the event payloads the domain refuses to dereference, and orchestrates `create`/`attachEvents`/`reinforce`/`relate` — adding no new domain rules. Timestamps enter via the `Clock`; ids are minted inside the domain factories.
+- It resolves the **one judgment call the domain left open** — `graphId` per event — behind a swappable policy, and honors the **one hard boundary the domain set** — provenance is `eventIds`, never a `DERIVED_FROM` edge.
+- Idempotency is anchored on the deterministic **event id** (ledger), kept distinct from **progress** (cursor), so the pipeline is safe under at-least-once delivery _and_ non-deterministic extraction.
+- Everything impure — trigger, event source, extractor, embedder, store — is **behind a port**, so the trigger graduation (push ⇄ reconcile), the integration graduation (shared-DB → published payload), and the store graduations of `database-tradeoffs.md` all stay **adapter-local**. The application core never moves.
+</content>

--- a/docs/thoughts/feature-knowledge-graph-processing.md
+++ b/docs/thoughts/feature-knowledge-graph-processing.md
@@ -96,6 +96,8 @@ The depth lives in four focused sub-docs. Read in pipeline order:
 3. **[Entity resolution & embedding](./feature-knowledge-graph-processing-resolution.md)** — deciding a candidate **is** an existing node (deterministic key → vector ANN → defer); the pure `EntityResolution.classify` decision; `EmbedNodes` triggers; node-body canonicalization. Ports: `NodeResolutionIndex`, `EmbeddingGateway`, the node/edge repositories.
 4. **[Idempotency, consistency & multi-tenancy](./feature-knowledge-graph-processing-idempotency.md)** — at-least-once safety (the processed-events ledger, `factHash`, extractor versioning); the transaction boundary (context-owned unit-of-work); ordering / poison events / back-pressure; resolving a `graphId` per event. Ports: `ProcessedEventLedger`, `GraphResolution`, `UnitOfWork`.
 
+For the build-out, the **[implementation tasks](./feature-knowledge-graph-processing-tasks.md)** doc decomposes this design use-case by use-case (`EnrichEvents` / `EmbedNodes` / `MergeDuplicateNodes`) into ordered sub-tasks with verification checks.
+
 ---
 
 ## 6. Decisions, alternatives, and deferred work


### PR DESCRIPTION
## Summary

Restructure the knowledge graph processing design documentation by splitting the monolithic `feature-knowledge-graph-processing.md` into focused sub-documents, each covering a specific concern. Update the main doc to reflect the current state of the codebase and recent architectural decisions around event publication and worker triggering.

## Key Changes

- **Split main doc into four sub-documents:**
  - `feature-knowledge-graph-processing-event-consumption.md` — Event triggering (SQS push + cursor reconcile), cross-context integration via shared-DB ACL
  - `feature-knowledge-graph-processing-extraction.md` — Hybrid extraction (rules + LLM), vocabulary enforcement
  - `feature-knowledge-graph-processing-resolution.md` — Entity resolution (natural key + vector ANN + deferred merge), embedding lifecycle, body canonicalization
  - `feature-knowledge-graph-processing-idempotency.md` — At-least-once safety, transaction boundaries, extractor versioning, multi-tenancy

- **Update main doc (`feature-knowledge-graph-processing.md`):**
  - Reflect that event publication is now built (outbox → SQS, ADR `20260524`), not a future seam
  - Replace the two-approach decision (pull vs push) with the realized hybrid: SQS push as hot path, cursor reconcile as safety net
  - Remove deferred sections (§3–4 on event consumption and context mapping) — now in sub-docs
  - Add "State of the code (2026-05)" callout documenting what is on disk (domain aggregates, create/restore only) vs what remains to build (mutators, services, application layer, infra)
  - Clarify that `IdGenerator` port is unnecessary — domain factories mint IDs internally
  - Simplify building-blocks section to reference the actual built types and ADRs
  - Condense use-case decomposition and remove redundant rationale tables (now in sub-docs)
  - Update terminology: `Worker` → `apps/server-knowledge-worker`, `@repo/knowledge-graph-infra` → `@repo/server-knowledge-infra`, `@repo/kernel` → `@repo/server-kernel`, etc.

- **Preserve design intent:**
  - Anti-corruption layer (ACL) for shared-DB event reads
  - Conservative entity resolution (defer ambiguous merges)
  - Split embedding into separate use case for failure isolation
  - Deterministic extraction where possible, LLM for free-text
  - Idempotency anchored on `eventId`, not extractor output

## Notable Details

- Event consumption sub-doc explains why the cursor is kept despite SQS push existing (eventual completeness, broker resilience)
- Idempotency sub-doc clarifies the split between checkpoint (progress) and processed-events ledger (effect), and how extractor versioning enables legitimate reprocessing
- Resolution sub-doc documents the pure `EntityResolution.classify` domain service that keeps threshold policy testable
- All sub-docs cross-reference each other and the main doc, maintaining coherence

https://claude.ai/code/session_01LhoRYrviatmtTTqNtdVbY7