### PR TITLE
Add health check endpoint to outbox worker

### DIFF
--- a/apps/server-outbox-worker/package.json
+++ b/apps/server-outbox-worker/package.json
@@ -13,6 +13,7 @@
     "@repo/server-database": "workspace:*",
     "@repo/server-ingestion-infra": "workspace:*",
     "@repo/server-platform": "workspace:*",
+    "hono": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/server-outbox-worker/src/index.test.ts
+++ b/apps/server-outbox-worker/src/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { loadWorkerConfig } from "./index.ts";
+import { app, loadWorkerConfig } from "./index.ts";
 
 const validEnv = {
   AWS_REGION: "us-east-1",
@@ -23,4 +23,13 @@ test("loadWorkerConfig: given a missing queue url, it should throw", () => {
   expect(() => loadWorkerConfig({ AWS_REGION: "us-east-1" })).toThrow(
     /Invalid worker configuration/,
   );
+});
+
+test("GET /api/v1/health: it should respond ok", async () => {
+  // when
+  const res = await app.request("/api/v1/health");
+
+  // then
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ message: "ok" });
 });

--- a/apps/server-outbox-worker/src/index.ts
+++ b/apps/server-outbox-worker/src/index.ts
@@ -2,7 +2,11 @@ import { SQSClient } from "@aws-sdk/client-sqs";
 import { createPrismaClient } from "@repo/server-database";
 import { OutboxRelay, SqsOutboxBroker } from "@repo/server-ingestion-infra";
 import { createLogger, loadConfig } from "@repo/server-platform";
+import { Hono } from "hono";
 import { z } from "zod";
+
+export const app = new Hono();
+app.get("/api/v1/health", (c) => c.json({ message: "ok" }));
 
 const workerConfigSchema = z.object({
   AWS_REGION: z.string().min(1),
@@ -43,6 +47,11 @@ async function main(): Promise<void> {
     workerConfig.OUTBOX_RELAY_BATCH_SIZE,
   );
 
+  // The relay loop has no inbound traffic, so the health server is the only
+  // way for an orchestrator to probe liveness while the worker drains the outbox.
+  const server = Bun.serve({ port: config.PORT, fetch: app.fetch });
+  logger.info({ port: config.PORT }, "outbox worker health server started");
+
   let running = true;
   const stop = (signal: string): void => {
     logger.info({ signal }, "outbox relay received shutdown signal");
@@ -70,6 +79,7 @@ async function main(): Promise<void> {
     }
   }
 
+  await server.stop();
   await prisma.$disconnect();
   sqs.destroy();
   logger.info("outbox relay stopped");

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@repo/server-database": "workspace:*",
         "@repo/server-ingestion-infra": "workspace:*",
         "@repo/server-platform": "workspace:*",
+        "hono": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
Add a health check HTTP endpoint to the outbox worker to enable orchestrators to probe liveness while the worker processes the outbox relay.

## Changes
- Introduce Hono web framework to the outbox worker
- Create a `GET /api/v1/health` endpoint that returns `{ message: "ok" }` with a 200 status
- Start an HTTP server on the configured PORT alongside the outbox relay loop
- Properly shut down the health server during graceful shutdown
- Add test coverage for the health endpoint

## Implementation Details
The health server runs independently of the outbox relay processing loop, allowing orchestrators to monitor worker liveness without interfering with the relay's message processing. The server is started after the relay is initialized and stopped during graceful shutdown before disconnecting from the database.

https://claude.ai/code/session_01TavUqSt5SoQc5HChpwhnZL