### PR TITLE
refactor(config): derive app config types from Zod schemas

### DIFF
--- a/apps/server-api/package.json
+++ b/apps/server-api/package.json
@@ -16,6 +16,7 @@
     "@repo/server-kernel": "workspace:*",
     "@repo/server-platform": "workspace:*",
     "convict": "catalog:",
+    "type-fest": "catalog:",
     "hono": "catalog:"
   },
   "devDependencies": {

--- a/apps/server-api/src/config.test.ts
+++ b/apps/server-api/src/config.test.ts
@@ -53,7 +53,12 @@ describe("server API config", () => {
   test.each([
     [{ APP_ENV: "development" }, "Unsupported APP_ENV"],
     [{ HTTP_PORT: "invalid" }, "app.http.port"],
+    [{ HTTP_PORT: "65536" }, "app.http.port"],
     [{ INGESTION_MONGODB_URL: "" }, "ingestion.mongodb.url"],
+    [
+      { INGESTION_MONGODB_DATABASE_NAME: "   " },
+      "ingestion.mongodb.databaseName",
+    ],
   ])("rejects invalid environment input", (env, message) => {
     expect(() => createConfig({ env })).toThrow(message);
   });

--- a/apps/server-api/src/config.ts
+++ b/apps/server-api/src/config.ts
@@ -4,42 +4,41 @@ import localProfile from "../config/local.json";
 import productionProfile from "../config/production.json";
 import stagingProfile from "../config/staging.json";
 
-type AppEnvironment = "local" | "staging" | "production";
+const appEnvironmentSchema = z.enum(["local", "staging", "production"]);
+const requiredStringSchema = z.string().trim().min(1);
+const portSchema = z.number().int().min(1).max(65_535);
 
-type ServerApiConfig = {
-  readonly app: {
-    readonly environment: AppEnvironment;
-    readonly version: string;
-    readonly http: {
-      readonly port: number;
-    };
-  };
-  readonly ingestion: {
-    readonly mongodb: {
-      readonly url: string;
-      readonly databaseName: string;
-    };
-  };
-};
-
-const requiredString = (value: unknown): asserts value is string => {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    throw new Error("must be a non-empty string");
+    environment: appEnvironmentSchema,
+    version: requiredStringSchema,
+      port: portSchema,
+    }),
+  }),
+  ingestion: z.object({
+    mongodb: z.object({
+      url: requiredStringSchema,
+      databaseName: requiredStringSchema,
+type ServerApiConfig = ReadonlyDeep<z.infer<typeof serverApiConfigSchema>>;
+const convictConfigSchema: Schema<ServerApiConfig> = {
+      format: appEnvironmentSchema.options,
+      format: (value) =>
+        serverApiConfigSchema.shape.app.shape.version.parse(value),
+        format: (value) =>
+          serverApiConfigSchema.shape.app.shape.http.shape.port.parse(value),
+        format: (value) =>
+          serverApiConfigSchema.shape.ingestion.shape.mongodb.shape.url.parse(
+            value,
+          ),
+        format: (value) =>
+          serverApiConfigSchema.shape.ingestion.shape.mongodb.shape.databaseName.parse(
+            value,
+          ),
+  const config = convict(convictConfigSchema, {
+    env: options.env ?? process.env,
+  });
   }
-};
+  return serverApiConfigSchema.parse(config.getProperties());
 
-const positivePort = (value: unknown): asserts value is number => {
-  if (
-    typeof value !== "number" ||
-    !Number.isInteger(value) ||
-    value < 1 ||
-    value > 65_535
-  ) {
-    throw new Error("must be an integer between 1 and 65535");
-  }
-};
-
-const configSchema: Schema<ServerApiConfig> = {
+export { convictConfigSchema, createConfig, serverApiConfigSchema };
   app: {
     environment: {
       doc: "Application deployment environment",

--- a/apps/server-worker/package.json
+++ b/apps/server-worker/package.json
@@ -16,7 +16,9 @@
     "@repo/server-knowledge-outbound-adapter": "workspace:*",
     "@repo/server-platform": "workspace:*",
     "convict": "catalog:",
-    "hono": "catalog:"
+    "hono": "catalog:",
+    "type-fest": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/apps/server-worker/src/config.test.ts
+++ b/apps/server-worker/src/config.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import convict from "convict";
 
 import localProfile from "../config/local.json";
-import { configSchema, createConfig } from "./config.ts";
+import { convictConfigSchema, createConfig } from "./config.ts";
 
 const localEnv = {
   KNOWLEDGE_VOYAGEAI_API_KEY: "voyage-test-key",
@@ -74,13 +74,18 @@ describe("server worker config", () => {
   test.each([
     [{ APP_ENV: "development", ...localEnv }, "Unsupported APP_ENV"],
     [{ HTTP_PORT: "0", ...localEnv }, "app.http.port"],
+    [{ HTTP_PORT: "65536", ...localEnv }, "app.http.port"],
     [{ ...localEnv, KNOWLEDGE_MONGODB_URL: "" }, "knowledge.mongodb.url"],
+    [
+      { ...localEnv, KNOWLEDGE_MONGODB_DATABASE_NAME: "   " },
+      "knowledge.mongodb.databaseName",
+    ],
   ])("rejects invalid environment input", (env, message) => {
     expect(() => createConfig({ env })).toThrow(message);
   });
 
   test("masks the Voyage AI key when Convict serializes config", () => {
-    const config = convict(configSchema, { env: localEnv });
+    const config = convict(convictConfigSchema, { env: localEnv });
     config.load(localProfile).validate({ allowed: "strict" });
 
     expect(config.toString()).not.toContain("voyage-test-key");

--- a/apps/server-worker/src/config.ts
+++ b/apps/server-worker/src/config.ts
@@ -1,71 +1,65 @@
+import type { ReadonlyDeep } from "type-fest";
+
 import convict, { type Schema } from "convict";
+import z from "zod";
 
 import localProfile from "../config/local.json";
 import productionProfile from "../config/production.json";
 import stagingProfile from "../config/staging.json";
 
-type AppEnvironment = "local" | "staging" | "production";
+const appEnvironmentSchema = z.enum(["local", "staging", "production"]);
+const requiredStringSchema = z.string().trim().min(1);
+const portSchema = z.number().int().min(1).max(65_535);
 
-type ServerWorkerConfig = {
-  readonly app: {
-    readonly environment: AppEnvironment;
-    readonly version: string;
-    readonly http: {
-      readonly port: number;
-    };
-  };
-  readonly ingestion: {
-    readonly mongodb: {
-      readonly url: string;
-      readonly databaseName: string;
-    };
-  };
-  readonly knowledge: {
-    readonly mongodb: {
-      readonly url: string;
-      readonly databaseName: string;
-    };
-    readonly voyageai: {
-      readonly apiKey: string;
-    };
-  };
-};
+const serverWorkerConfigSchema = z.object({
+  app: z.object({
+    environment: appEnvironmentSchema,
+    version: requiredStringSchema,
+    http: z.object({
+      port: portSchema,
+    }),
+  }),
+  ingestion: z.object({
+    mongodb: z.object({
+      url: requiredStringSchema,
+      databaseName: requiredStringSchema,
+    }),
+  }),
+  knowledge: z.object({
+    mongodb: z.object({
+      url: requiredStringSchema,
+      databaseName: requiredStringSchema,
+    }),
+    voyageai: z.object({
+      apiKey: requiredStringSchema,
+    }),
+  }),
+});
 
-const requiredString = (value: unknown): asserts value is string => {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    throw new Error("must be a non-empty string");
-  }
-};
+type ServerWorkerConfig = ReadonlyDeep<
+  z.infer<typeof serverWorkerConfigSchema>
+>;
 
-const positivePort = (value: unknown): asserts value is number => {
-  if (
-    typeof value !== "number" ||
-    !Number.isInteger(value) ||
-    value < 1 ||
-    value > 65_535
-  ) {
-    throw new Error("must be an integer between 1 and 65535");
-  }
-};
-
-const configSchema: Schema<ServerWorkerConfig> = {
+const convictConfigSchema: Schema<ServerWorkerConfig> = {
   app: {
     environment: {
       doc: "Application deployment environment",
-      format: ["local", "staging", "production"],
+      format: appEnvironmentSchema.options,
       default: "local",
       env: "APP_ENV",
     },
     version: {
       doc: "Application version",
-      format: String,
+      format: (value) =>
+        serverWorkerConfigSchema.shape.app.shape.version.parse(value),
       default: "0.0.0",
       env: "APP_VERSION",
     },
     http: {
       port: {
         doc: "HTTP port",
-        format: positivePort,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.app.shape.http.shape.port.parse(value),
         default: 8000,
         env: "HTTP_PORT",
       },
@@ -75,13 +69,19 @@ const configSchema: Schema<ServerWorkerConfig> = {
     mongodb: {
       url: {
         doc: "Ingestion MongoDB connection URL",
-        format: requiredString,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.ingestion.shape.mongodb.shape.url.parse(
+            value,
+          ),
         default: null,
         env: "INGESTION_MONGODB_URL",
       },
       databaseName: {
         doc: "Ingestion MongoDB database name",
-        format: requiredString,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.ingestion.shape.mongodb.shape.databaseName.parse(
+            value,
+          ),
         default: null,
         env: "INGESTION_MONGODB_DATABASE_NAME",
       },
@@ -91,13 +91,19 @@ const configSchema: Schema<ServerWorkerConfig> = {
     mongodb: {
       url: {
         doc: "Knowledge MongoDB connection URL",
-        format: requiredString,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.knowledge.shape.mongodb.shape.url.parse(
+            value,
+          ),
         default: null,
         env: "KNOWLEDGE_MONGODB_URL",
       },
       databaseName: {
         doc: "Knowledge MongoDB database name",
-        format: requiredString,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.knowledge.shape.mongodb.shape.databaseName.parse(
+            value,
+          ),
         default: null,
         env: "KNOWLEDGE_MONGODB_DATABASE_NAME",
       },
@@ -105,7 +111,10 @@ const configSchema: Schema<ServerWorkerConfig> = {
     voyageai: {
       apiKey: {
         doc: "Voyage AI API key",
-        format: requiredString,
+        format: (value) =>
+          serverWorkerConfigSchema.shape.knowledge.shape.voyageai.shape.apiKey.parse(
+            value,
+          ),
         default: null,
         env: "KNOWLEDGE_VOYAGEAI_API_KEY",
         sensitive: true,
@@ -127,7 +136,9 @@ type CreateConfigOptions = {
 const createConfig = (
   options: CreateConfigOptions = {},
 ): ServerWorkerConfig => {
-  const config = convict(configSchema, { env: options.env ?? process.env });
+  const config = convict(convictConfigSchema, {
+    env: options.env ?? process.env,
+  });
   const environment = config.get("app.environment");
 
   if (!Object.hasOwn(profiles, environment)) {
@@ -137,8 +148,8 @@ const createConfig = (
   config.load(profiles[environment]);
   config.validate({ allowed: "strict" });
 
-  return config.getProperties();
+  return serverWorkerConfigSchema.parse(config.getProperties());
 };
 
-export { configSchema, createConfig };
+export { convictConfigSchema, createConfig, serverWorkerConfigSchema };
 export type { ServerWorkerConfig };

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@repo/server-platform": "workspace:*",
         "convict": "catalog:",
         "hono": "catalog:",
+        "type-fest": "catalog:",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
@@ -42,6 +43,8 @@
         "@repo/server-platform": "workspace:*",
         "convict": "catalog:",
         "hono": "catalog:",
+        "type-fest": "catalog:",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",


### PR DESCRIPTION
### Motivation
- Move config validation and type derivation to Zod while keeping Convict as the loader so config types are authoritative and runtime-validated.
- Replace ad-hoc helper validators with Zod field schemas and ensure final runtime shape is parsed by Zod.

### Description
- Add full Zod schemas: `serverApiConfigSchema` and `serverWorkerConfigSchema`, and derive `ServerApiConfig` / `ServerWorkerConfig` as `ReadonlyDeep<z.infer<...>>`.
- Rename the existing Convict contract to `convictConfigSchema` and update exports and consumers accordingly.
- Remove `requiredString` and `positivePort` helpers and use Zod parsing inside Convict `format` callbacks; parse the final `config.getProperties()` with Zod before returning.
- Update tests to import `convictConfigSchema` where needed and extend invalid-case coverage (out-of-range ports, blank strings); add `type-fest` and `zod` to the apps that require them.

### Testing
- Ran formatting with `bun run fmt` (repo formatter executed during the rollout).
- Ran per-app lint: `(cd apps/server-api && bun run lint) && (cd apps/server-worker && bun run lint)` and both packages linted successfully when run individually.
- Ran unit tests for both apps with `PATH="$HOME/.bun/bin:$PATH" bun run test --filter ./apps/server-api --filter ./apps/server-worker` and all config tests passed.
- Built both apps with `PATH="$HOME/.bun/bin:$PATH" bun run build --filter ./apps/server-api --filter ./apps/server-worker` and builds succeeded.
- Note: a Turbo-scoped lint (`bun run lint --filter ./apps/server-api --filter ./apps/server-worker`) was attempted but failed because Turbo ran lint across dependent packages and hit a pre-existing unrelated lint error in `@repo/server-kernel` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356bfb6810832dbb7b84c4bda2f439)