### PR TITLE
fix: address PR #60 review feedback

### DIFF
--- a/apps/server-worker/src/config.test.ts
+++ b/apps/server-worker/src/config.test.ts
@@ -53,7 +53,7 @@ describe("server worker config", () => {
         },
         voyageai: {
           apiKey: "voyage-test-key",
-          embeddingsUrl: "https://api.voyageai.com/v1/embeddings",
+          baseUrl: "https://api.voyageai.com/v1",
         },
       },
     });
@@ -72,8 +72,7 @@ describe("server worker config", () => {
       INGESTION_MONGODB_DATABASE_NAME: "ingestion",
       KNOWLEDGE_MONGODB_URL: "mongodb://knowledge:27017",
       KNOWLEDGE_MONGODB_DATABASE_NAME: "knowledge",
-      KNOWLEDGE_VOYAGEAI_EMBEDDINGS_URL:
-        "http://voyage-fixture:8080/v1/embeddings",
+      KNOWLEDGE_VOYAGEAI_BASE_URL: "http://voyage-fixture:8080/v1",
     });
 
     expect(config.app).toEqual({
@@ -83,8 +82,8 @@ describe("server worker config", () => {
     });
     expect(config.ingestion.mongodb.databaseName).toBe("ingestion");
     expect(config.knowledge.mongodb.databaseName).toBe("knowledge");
-    expect(config.knowledge.voyageai.embeddingsUrl).toBe(
-      "http://voyage-fixture:8080/v1/embeddings",
+    expect(config.knowledge.voyageai.baseUrl).toBe(
+      "http://voyage-fixture:8080/v1",
     );
   });
 
@@ -103,8 +102,8 @@ describe("server worker config", () => {
     [{ HTTP_PORT: "65536", ...localEnv }, "app.http.port"],
     [{ ...localEnv, KNOWLEDGE_MONGODB_URL: "" }, "knowledge.mongodb.url"],
     [
-      { ...localEnv, KNOWLEDGE_VOYAGEAI_EMBEDDINGS_URL: "not-a-url" },
-      "knowledge.voyageai.embeddingsUrl",
+      { ...localEnv, KNOWLEDGE_VOYAGEAI_BASE_URL: "not-a-url" },
+      "knowledge.voyageai.baseUrl",
     ],
     [
       { ...localEnv, KNOWLEDGE_MONGODB_DATABASE_NAME: "   " },

--- a/apps/server-worker/src/config.ts
+++ b/apps/server-worker/src/config.ts
@@ -32,7 +32,7 @@ const serverWorkerConfigSchema = z.object({
     }),
     voyageai: z.object({
       apiKey: requiredStringSchema,
-      embeddingsUrl: z.url(),
+      baseUrl: z.url(),
     }),
   }),
 });
@@ -118,14 +118,14 @@ const convictConfigSchema: Schema<ServerWorkerConfig> = {
         env: "KNOWLEDGE_VOYAGEAI_API_KEY",
         sensitive: true,
       },
-      embeddingsUrl: {
-        doc: "Voyage AI embeddings URL",
+      baseUrl: {
+        doc: "Voyage AI API base URL",
         format: (value) =>
-          serverWorkerConfigSchema.shape.knowledge.shape.voyageai.shape.embeddingsUrl.parse(
+          serverWorkerConfigSchema.shape.knowledge.shape.voyageai.shape.baseUrl.parse(
             value,
           ),
-        default: "https://api.voyageai.com/v1/embeddings",
-        env: "KNOWLEDGE_VOYAGEAI_EMBEDDINGS_URL",
+        default: "https://api.voyageai.com/v1",
+        env: "KNOWLEDGE_VOYAGEAI_BASE_URL",
       },
     },
   },

--- a/apps/server-worker/src/knowledge.ts
+++ b/apps/server-worker/src/knowledge.ts
@@ -24,7 +24,7 @@ const graphNodeRepository = new MongodbGraphNodeRepository(
 );
 const embeddingGateway = new VoyageaiEmbeddingGateway(
   config.knowledge.voyageai.apiKey,
-  config.knowledge.voyageai.embeddingsUrl,
+  config.knowledge.voyageai.baseUrl,
 );
 
 const processEventUseCase = new ProcessEventUseCase(

--- a/compose.apps.yml
+++ b/compose.apps.yml
@@ -28,7 +28,7 @@ services:
       KNOWLEDGE_MONGODB_URL: mongodb://mongo:27017/?directConnection=true&replicaSet=rs0
       KNOWLEDGE_MONGODB_DATABASE_NAME: recallos-system-test
       KNOWLEDGE_VOYAGEAI_API_KEY: e2e-test-key
-      KNOWLEDGE_VOYAGEAI_EMBEDDINGS_URL: http://mock:8080/v1/embeddings
+      KNOWLEDGE_VOYAGEAI_BASE_URL: http://mock:8080/v1
     depends_on:
       mongo:
         condition: service_healthy

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@
 #
 #   INGESTION_MONGODB_URL=mongodb://localhost:27017/?replicaSet=rs0
 #   INGESTION_MONGODB_DATABASE_NAME=recallos
-#   KNOWLEDGE_VOYAGEAI_EMBEDDINGS_URL=http://localhost:4010/v1/embeddings
+#   KNOWLEDGE_VOYAGEAI_BASE_URL=http://localhost:4010/v1
 
 services:
   mongo:

--- a/packages/server-knowledge-core/src/application/ports/inbound/list-graph-nodes-port.ts
+++ b/packages/server-knowledge-core/src/application/ports/inbound/list-graph-nodes-port.ts
@@ -10,14 +10,16 @@ type ListGraphNodesPortInput = {
 
 type ListGraphNodesPortOutput = Promise<
   {
-    id: string;
-    tenant: string;
-    createdAt: string;
-    updatedAt: string;
-    eventId: string;
-    graphId: string;
-    rawEvent: JsonObject;
-  }[]
+    data: {
+      id: string;
+      tenant: string;
+      createdAt: string;
+      updatedAt: string;
+      eventId: string;
+      graphId: string;
+      rawEvent: JsonObject;
+    }[];
+  }
 >;
 
 interface ListGraphNodesPort {

--- a/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.test.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.test.ts
@@ -65,18 +65,20 @@ test("ListGraphNodesUseCase.execute: given matching graph nodes, it should retur
   expect(repositoryInput.tenant.toString()).toBe(tenant);
   expect(repositoryInput.filters.eventId.toString()).toBe(eventId);
   expect(repositoryInput.filters.graphId.toString()).toBe(graphId);
-  expect(output).toEqual([
-    {
-      id: graphNodeId,
-      tenant,
-      createdAt: createdAt.toISOString(),
-      updatedAt: updatedAt.toISOString(),
-      eventId,
-      graphId,
-      rawEvent,
-    },
-  ]);
-  expect(output[0]).not.toHaveProperty("embedding");
+  expect(output).toEqual({
+    data: [
+      {
+        id: graphNodeId,
+        tenant,
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+        eventId,
+        graphId,
+        rawEvent,
+      },
+    ],
+  });
+  expect(output.data[0]).not.toHaveProperty("embedding");
 });
 
 test("ListGraphNodesUseCase.execute: given no matching graph nodes, it should return an empty list", async () => {
@@ -87,5 +89,5 @@ test("ListGraphNodesUseCase.execute: given no matching graph nodes, it should re
     filters: { eventId, graphId },
   });
 
-  expect(output).toEqual([]);
+  expect(output).toEqual({ data: [] });
 });

--- a/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.ts
@@ -22,15 +22,17 @@ class ListGraphNodesUseCase implements ListGraphNodesPort {
       },
     });
 
-    return graphNodes.map((graphNode) => ({
-      id: graphNode.id.toString(),
-      tenant: graphNode.tenant.toString(),
-      createdAt: graphNode.metadata.createdAt.toISOString(),
-      updatedAt: graphNode.metadata.updatedAt.toISOString(),
-      eventId: graphNode.eventId.toString(),
-      graphId: graphNode.graphId.toString(),
-      rawEvent: graphNode.rawEvent,
-    }));
+    return {
+      data: graphNodes.map((graphNode) => ({
+        id: graphNode.id.toString(),
+        tenant: graphNode.tenant.toString(),
+        createdAt: graphNode.metadata.createdAt.toISOString(),
+        updatedAt: graphNode.metadata.updatedAt.toISOString(),
+        eventId: graphNode.eventId.toString(),
+        graphId: graphNode.graphId.toString(),
+        rawEvent: graphNode.rawEvent,
+      })),
+    };
   }
 }
 

--- a/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.test.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.test.ts
@@ -26,13 +26,13 @@ class FakeListGraphNodes implements ListGraphNodesPort {
 
   execute(input: ListGraphNodesPortInput): ListGraphNodesPortOutput {
     this.executeCalls.push(input);
-    return Promise.resolve([graphNode]);
+    return Promise.resolve({ data: [graphNode] });
   }
 }
 
 class EmptyListGraphNodes implements ListGraphNodesPort {
   execute(): ListGraphNodesPortOutput {
-    return Promise.resolve([]);
+    return Promise.resolve({ data: [] });
   }
 }
 
@@ -58,7 +58,7 @@ test("createGraphNodeRoutes: given matching graph nodes, it should return the gr
 
   // THEN
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual([graphNode]);
+  expect(await response.json()).toEqual({ data: [graphNode] });
   expect(listGraphNodes.executeCalls).toEqual([
     { tenant, filters: { eventId, graphId } },
   ]);
@@ -77,7 +77,7 @@ test("createGraphNodeRoutes: given no matching graph nodes, it should return an 
 
   // THEN
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual([]);
+  expect(await response.json()).toEqual({ data: [] });
 });
 
 test("createGraphNodeRoutes: given a missing tenant, it should return 422 without calling the use case", async () => {

--- a/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.test.ts
+++ b/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.test.ts
@@ -64,7 +64,7 @@ test("VoyageaiEmbeddingGateway.embed: given an unsuccessful response, it should 
   ).rejects.toThrow("Voyage AI embedding request failed with status 429");
 });
 
-test("VoyageaiEmbeddingGateway.embed: given a custom embeddings URL, it should request that URL", async () => {
+test("VoyageaiEmbeddingGateway.embed: given a custom base URL, it should request its embeddings endpoint", async () => {
   // GIVEN
   const fetchMock = mock(() =>
     Promise.resolve(
@@ -74,8 +74,8 @@ test("VoyageaiEmbeddingGateway.embed: given a custom embeddings URL, it should r
     ),
   );
   globalThis.fetch = fetchMock as unknown as typeof fetch;
-  const embeddingsUrl = "http://127.0.0.1:3001/v1/embeddings";
-  const gateway = new VoyageaiEmbeddingGateway("test-api-key", embeddingsUrl);
+  const baseUrl = "http://127.0.0.1:3001/v1";
+  const gateway = new VoyageaiEmbeddingGateway("test-api-key", baseUrl);
 
   // WHEN
   await gateway.embed({
@@ -85,5 +85,8 @@ test("VoyageaiEmbeddingGateway.embed: given a custom embeddings URL, it should r
   });
 
   // THEN
-  expect(fetchMock).toHaveBeenCalledWith(embeddingsUrl, expect.any(Object));
+  expect(fetchMock).toHaveBeenCalledWith(
+    "http://127.0.0.1:3001/v1/embeddings",
+    expect.any(Object),
+  );
 });

--- a/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.ts
+++ b/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.ts
@@ -6,7 +6,7 @@ import type {
 
 import { z } from "zod";
 
-const VOYAGEAI_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
+const VOYAGEAI_BASE_URL = "https://api.voyageai.com/v1";
 
 const voyageaiEmbeddingResponseSchema = z.object({
   data: z.tuple([
@@ -20,13 +20,18 @@ const voyageaiEmbeddingResponseSchema = z.object({
 class VoyageaiEmbeddingGateway implements EmbeddingGatewayPort {
   constructor(
     private readonly apiKey: string,
-    private readonly embeddingsUrl = VOYAGEAI_EMBEDDINGS_URL,
+    private readonly baseUrl = VOYAGEAI_BASE_URL,
   ) {}
 
   async embed(
     input: EmbeddingGatewayPortEmbedInput,
   ): EmbeddingGatewayPortEmbedOutput {
-    const response = await fetch(this.embeddingsUrl, {
+    const embeddingsUrl = new URL(
+      "embeddings",
+      this.baseUrl.endsWith("/") ? this.baseUrl : `${this.baseUrl}/`,
+    ).toString();
+
+    const response = await fetch(embeddingsUrl, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.apiKey}`,


### PR DESCRIPTION
Follow-up to https://github.com/teytattze/recallos/pull/60

Addresses:
- `discussion_r3455322469`: rename the Voyage AI configuration to `baseUrl`, derive the `/embeddings` endpoint in the gateway, and update compose/config usage.
- `discussion_r3455339248`: return graph-node lists as `{ data: [...] }`, including empty results and HTTP responses.

Verification:
- `bun run test` in `apps/server-worker` (12 passed)
- `bun run test` in `packages/server-knowledge-core` (4 passed)
- `bun run test` in `packages/server-knowledge-inbound-adapter` (10 passed)
- `bun run test` in `packages/server-knowledge-outbound-adapter` (12 passed)
- `bun run build` in `apps/server-worker` (passed)
- Direct lint in all four affected workspaces (passed)

Independent review found no issues.