### PR TITLE
Add knowledge graph node search

### DIFF
--- a/apps/server-api/config/local.json
+++ b/apps/server-api/config/local.json
@@ -33,6 +33,9 @@
     "mongodb": {
       "url": "mongodb://localhost:27017/?replicaSet=rs0",
       "databaseName": "recallos"
+    },
+    "voyageai": {
+      "apiKey": "local-voyageai-api-key"
     }
   }
 }

--- a/apps/server-api/src/config.test.ts
+++ b/apps/server-api/src/config.test.ts
@@ -70,6 +70,7 @@ describe("server API config", () => {
           url: "mongodb://localhost:27017/?replicaSet=rs0",
           databaseName: "recallos",
         },
+        voyageai: { apiKey: "local-voyageai-api-key" },
       },
     });
   });
@@ -99,6 +100,7 @@ describe("server API config", () => {
       IAM_API_KEY_RATE_LIMIT_TIME_WINDOW_MILLISECONDS: "60000",
       KNOWLEDGE_MONGODB_URL: "mongodb://knowledge-database:27017",
       KNOWLEDGE_MONGODB_DATABASE_NAME: "knowledge-test",
+      KNOWLEDGE_VOYAGEAI_API_KEY: "pa_test",
     });
 
     expect(config.app).toEqual({
@@ -141,9 +143,12 @@ describe("server API config", () => {
         },
       },
     });
-    expect(config.knowledge.mongodb).toEqual({
-      url: "mongodb://knowledge-database:27017",
-      databaseName: "knowledge-test",
+    expect(config.knowledge).toEqual({
+      mongodb: {
+        url: "mongodb://knowledge-database:27017",
+        databaseName: "knowledge-test",
+      },
+      voyageai: { apiKey: "pa_test" },
     });
   });
 
@@ -175,6 +180,7 @@ describe("server API config", () => {
       { KNOWLEDGE_MONGODB_DATABASE_NAME: "   " },
       "knowledge.mongodb.databaseName",
     ],
+    [{ KNOWLEDGE_VOYAGEAI_API_KEY: "" }, "knowledge.voyageai.apiKey"],
   ])("rejects invalid environment input", (env, message) => {
     expect(() => createServerApiConfig(env)).toThrow(message);
   });

--- a/apps/server-api/src/config.ts
+++ b/apps/server-api/src/config.ts
@@ -91,6 +91,9 @@ const serverApiConfigSchema = z.object({
       url: requiredStringSchema,
       databaseName: requiredStringSchema,
     }),
+    voyageai: z.object({
+      apiKey: requiredStringSchema,
+    }),
   }),
 });
 
@@ -306,6 +309,18 @@ const convictConfigSchema: Schema<ServerApiConfig> = {
           ),
         default: null,
         env: "KNOWLEDGE_MONGODB_DATABASE_NAME",
+      },
+    },
+    voyageai: {
+      apiKey: {
+        doc: "Voyage AI API key for knowledge embeddings",
+        format: (value) =>
+          serverApiConfigSchema.shape.knowledge.shape.voyageai.shape.apiKey.parse(
+            value,
+          ),
+        default: null,
+        env: "KNOWLEDGE_VOYAGEAI_API_KEY",
+        sensitive: true,
       },
     },
   },

--- a/apps/server-api/src/index.test.ts
+++ b/apps/server-api/src/index.test.ts
@@ -12,6 +12,7 @@ const withServerApiEnv = async <T>(run: () => Promise<T>): Promise<T> => {
     KNOWLEDGE_MONGODB_URL: process.env.KNOWLEDGE_MONGODB_URL,
     KNOWLEDGE_MONGODB_DATABASE_NAME:
       process.env.KNOWLEDGE_MONGODB_DATABASE_NAME,
+    KNOWLEDGE_VOYAGEAI_API_KEY: process.env.KNOWLEDGE_VOYAGEAI_API_KEY,
   };
   try {
     process.env.APP_ENV = "local";
@@ -20,6 +21,7 @@ const withServerApiEnv = async <T>(run: () => Promise<T>): Promise<T> => {
     process.env.INGESTION_MONGODB_DATABASE_NAME = "recallos-test";
     process.env.KNOWLEDGE_MONGODB_URL = "mongodb://127.0.0.1:27017";
     process.env.KNOWLEDGE_MONGODB_DATABASE_NAME = "recallos-test";
+    process.env.KNOWLEDGE_VOYAGEAI_API_KEY = "pa_test";
 
     return await run();
   } finally {
@@ -71,6 +73,52 @@ test("server api fetch: given a graph node request without an IAM API key, it sh
     new Request(
       "http://localhost/api/v1/graphs/01952d3f-0000-7000-8000-000000000100/nodes?eventId=event-1",
     ),
+  );
+
+  // THEN
+  expect(response.status).toBe(401);
+  expect(await response.json()).toEqual({ message: "Unauthorized" });
+});
+
+test("server api fetch: given a knowledge search request without an IAM API key, it should return 401", async () => {
+  // GIVEN
+  const service = await withServerApiEnv(
+    () =>
+      import(
+        `./index.ts?knowledgeSearch=${Date.now()}`
+      ) as Promise<ServiceModule>,
+  );
+
+  // WHEN
+  const response = await service.default.fetch(
+    new Request(
+      "http://localhost/api/v1/graphs/01952d3f-0000-7000-8000-000000000100/search",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "billing incident" }),
+      },
+    ),
+  );
+
+  // THEN
+  expect(response.status).toBe(401);
+  expect(await response.json()).toEqual({ message: "Unauthorized" });
+});
+
+test("server api fetch: given an MCP request without an IAM API key, it should return 401", async () => {
+  // GIVEN
+  const service = await withServerApiEnv(
+    () => import(`./index.ts?mcp=${Date.now()}`) as Promise<ServiceModule>,
+  );
+
+  // WHEN
+  const response = await service.default.fetch(
+    new Request("http://localhost/api/v1/knowledge/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    }),
   );
 
   // THEN

--- a/apps/server-api/src/knowledge.ts
+++ b/apps/server-api/src/knowledge.ts
@@ -1,16 +1,25 @@
 import { createMongodbClient } from "@repo/server-database";
-import { ListGraphNodesUseCase } from "@repo/server-knowledge-core";
+import {
+  ListGraphNodesUseCase,
+  SearchGraphUseCase,
+} from "@repo/server-knowledge-core";
 import {
   createGraphNodeRoutes,
   createKnowledgeHttpApp,
+  createKnowledgeMcpRoutes,
 } from "@repo/server-knowledge-inbound-adapter";
-import { MongodbGraphNodeRepository } from "@repo/server-knowledge-outbound-adapter";
+import {
+  MongodbGraphNodeRepository,
+  MongodbGraphRepository,
+  VoyageaiEmbeddingGateway,
+} from "@repo/server-knowledge-outbound-adapter";
 
 import { config } from "./config.ts";
 import { getTenant, requireKnowledgeRead } from "./iam";
 
 // CONFIG
 const mongodbConfig = config.knowledge.mongodb;
+const voyageaiConfig = config.knowledge.voyageai;
 
 // OUTBOUND
 const mongodbClient = createMongodbClient({ url: mongodbConfig.url });
@@ -18,19 +27,38 @@ const graphNodeRepository = new MongodbGraphNodeRepository(
   mongodbClient,
   mongodbConfig.databaseName,
 );
+const graphRepository = new MongodbGraphRepository(
+  mongodbClient,
+  mongodbConfig.databaseName,
+);
+const embeddingGateway = new VoyageaiEmbeddingGateway(voyageaiConfig.apiKey);
 
 // CORE
 const listGraphNodesUseCase = new ListGraphNodesUseCase(graphNodeRepository);
+const searchGraphUseCase = new SearchGraphUseCase(
+  embeddingGateway,
+  graphRepository,
+  graphNodeRepository,
+);
 
 // INBOUND
 const graphNodeRoutes = createGraphNodeRoutes({
-  deps: { listGraphNodes: listGraphNodesUseCase },
+  deps: {
+    listGraphNodes: listGraphNodesUseCase,
+    searchGraph: searchGraphUseCase,
+  },
+  resolveTenant: getTenant,
+});
+const mcpRoutes = createKnowledgeMcpRoutes({
+  deps: { searchGraph: searchGraphUseCase },
   resolveTenant: getTenant,
 });
 const knowledgeHttpApp = createKnowledgeHttpApp({
   deps: {
     graphNodeMiddlewares: [requireKnowledgeRead],
     graphNodeRoutes,
+    mcpMiddlewares: [requireKnowledgeRead],
+    mcpRoutes,
   },
 });
 

--- a/packages/server-knowledge-core/src/application/ports/inbound/search-graph-port.ts
+++ b/packages/server-knowledge-core/src/application/ports/inbound/search-graph-port.ts
@@ -3,13 +3,13 @@ import type { JsonObject } from "type-fest";
 type SearchGraphPortInput = {
   tenant: string;
   payload: {
-    queries: string[];
+    graphId: string;
+    query: string;
   };
 };
 
 type SearchGraphPortOutput = Promise<{
-  graphId: string;
-  results: {
+  data: {
     rawEvent: JsonObject;
   }[];
 }>;

--- a/packages/server-knowledge-core/src/application/ports/outbound/embedding-gateway-port.ts
+++ b/packages/server-knowledge-core/src/application/ports/outbound/embedding-gateway-port.ts
@@ -2,6 +2,7 @@ type EmbeddingGatewayPortEmbedInput = {
   model: "voyage-4-large";
   dimension: "1024";
   text: string;
+  inputType: "document" | "query";
 };
 
 type EmbeddingGatewayPortEmbedOutput = Promise<{

--- a/packages/server-knowledge-core/src/application/ports/outbound/graph-node-repository-port.ts
+++ b/packages/server-knowledge-core/src/application/ports/outbound/graph-node-repository-port.ts
@@ -13,6 +13,16 @@ type GraphNodeRepositoryPortFindManyInput = {
 };
 type GraphNodeRepositoryPortFindManyOutput = Promise<GraphNode[]>;
 
+type GraphNodeRepositoryPortSearchByEmbeddingInput = {
+  tenant: Tenant;
+  filters: {
+    graphId: GraphId;
+  };
+  embedding: number[];
+  limit: number;
+};
+type GraphNodeRepositoryPortSearchByEmbeddingOutput = Promise<GraphNode[]>;
+
 type GraphNodeRepositoryPortInsertInput = {
   data: GraphNode;
 };
@@ -25,6 +35,9 @@ interface GraphNodeRepositoryPort {
   insert(
     input: GraphNodeRepositoryPortInsertInput,
   ): GraphNodeRepositoryPortInsertOutput;
+  searchByEmbedding(
+    input: GraphNodeRepositoryPortSearchByEmbeddingInput,
+  ): GraphNodeRepositoryPortSearchByEmbeddingOutput;
 }
 
 export type {
@@ -32,5 +45,7 @@ export type {
   GraphNodeRepositoryPortFindManyInput,
   GraphNodeRepositoryPortFindManyOutput,
   GraphNodeRepositoryPortInsertInput,
+  GraphNodeRepositoryPortSearchByEmbeddingInput,
+  GraphNodeRepositoryPortSearchByEmbeddingOutput,
   GraphNodeRepositoryPortInsertOutput,
 };

--- a/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.test.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/list-graph-nodes-use-case.test.ts
@@ -6,6 +6,8 @@ import type {
   GraphNodeRepositoryPortFindManyOutput,
   GraphNodeRepositoryPortInsertInput,
   GraphNodeRepositoryPortInsertOutput,
+  GraphNodeRepositoryPortSearchByEmbeddingInput,
+  GraphNodeRepositoryPortSearchByEmbeddingOutput,
 } from "../ports/outbound/graph-node-repository-port.ts";
 
 import { GraphNode } from "../../domain/aggregates/graph-node.ts";
@@ -27,6 +29,12 @@ class FakeGraphNodeRepository implements GraphNodeRepositoryPort {
     _input: GraphNodeRepositoryPortInsertInput,
   ): GraphNodeRepositoryPortInsertOutput {
     return Promise.resolve();
+  }
+
+  searchByEmbedding(
+    _input: GraphNodeRepositoryPortSearchByEmbeddingInput,
+  ): GraphNodeRepositoryPortSearchByEmbeddingOutput {
+    return Promise.resolve([]);
   }
 }
 

--- a/packages/server-knowledge-core/src/application/use-cases/process-event-use-case.test.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/process-event-use-case.test.ts
@@ -12,6 +12,8 @@ import type {
   GraphNodeRepositoryPortFindManyOutput,
   GraphNodeRepositoryPortInsertInput,
   GraphNodeRepositoryPortInsertOutput,
+  GraphNodeRepositoryPortSearchByEmbeddingInput,
+  GraphNodeRepositoryPortSearchByEmbeddingOutput,
 } from "../ports/outbound/graph-node-repository-port.ts";
 import type {
   GraphRepositoryPort,
@@ -49,6 +51,12 @@ class FakeGraphNodeRepository implements GraphNodeRepositoryPort {
   ): GraphNodeRepositoryPortInsertOutput {
     this.inputs.push(input);
     return Promise.resolve();
+  }
+
+  searchByEmbedding(
+    _input: GraphNodeRepositoryPortSearchByEmbeddingInput,
+  ): GraphNodeRepositoryPortSearchByEmbeddingOutput {
+    return Promise.resolve([]);
   }
 }
 
@@ -105,6 +113,7 @@ test("ProcessEventUseCase.execute: given an existing graph, it should embed and 
       dimension: "1024",
       model: "voyage-4-large",
       text: JSON.stringify(event.raw),
+      inputType: "document",
     },
   ]);
   expect(graphNodeRepository.inputs).toHaveLength(1);

--- a/packages/server-knowledge-core/src/application/use-cases/process-event-use-case.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/process-event-use-case.ts
@@ -42,6 +42,7 @@ class ProcessEventUseCase implements ProcessEventPort {
       dimension: graph.embeddingMetadata.dimension,
       model: graph.embeddingMetadata.model,
       text: JSON.stringify(input.payload.event.raw),
+      inputType: "document",
     });
 
     const graphNode = GraphNode.create({

--- a/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.test.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.test.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "bun:test";
+
+import type {
+  EmbeddingGatewayPort,
+  EmbeddingGatewayPortEmbedInput,
+  EmbeddingGatewayPortEmbedOutput,
+} from "../ports/outbound/embedding-gateway-port.ts";
+import type {
+  GraphNodeRepositoryPort,
+  GraphNodeRepositoryPortFindManyInput,
+  GraphNodeRepositoryPortFindManyOutput,
+  GraphNodeRepositoryPortInsertInput,
+  GraphNodeRepositoryPortInsertOutput,
+  GraphNodeRepositoryPortSearchByEmbeddingInput,
+  GraphNodeRepositoryPortSearchByEmbeddingOutput,
+} from "../ports/outbound/graph-node-repository-port.ts";
+import type {
+  GraphRepositoryPort,
+  GraphRepositoryPortCreateInput,
+  GraphRepositoryPortCreateOutput,
+  GraphRepositoryPortFindByIdInput,
+  GraphRepositoryPortFindByIdOutput,
+} from "../ports/outbound/graph-repository-port.ts";
+
+import { GraphNode } from "../../domain/aggregates/graph-node.ts";
+import { Graph } from "../../domain/aggregates/graph.ts";
+import { SearchGraphUseCase } from "./search-graph-use-case.ts";
+
+class FakeEmbeddingGateway implements EmbeddingGatewayPort {
+  readonly embedInputs: EmbeddingGatewayPortEmbedInput[] = [];
+
+  embed(
+    input: EmbeddingGatewayPortEmbedInput,
+  ): EmbeddingGatewayPortEmbedOutput {
+    this.embedInputs.push(input);
+    return Promise.resolve({ embedding: [0.4, 0.5] });
+  }
+}
+
+class FakeGraphRepository implements GraphRepositoryPort {
+  readonly findByIdInputs: GraphRepositoryPortFindByIdInput[] = [];
+
+  constructor(private readonly graph: Graph | null) {}
+
+  findById(
+    input: GraphRepositoryPortFindByIdInput,
+  ): GraphRepositoryPortFindByIdOutput {
+    this.findByIdInputs.push(input);
+    return Promise.resolve(this.graph);
+  }
+
+  create(
+    _input: GraphRepositoryPortCreateInput,
+  ): GraphRepositoryPortCreateOutput {
+    return Promise.resolve();
+  }
+}
+
+class FakeGraphNodeRepository implements GraphNodeRepositoryPort {
+  readonly searchInputs: GraphNodeRepositoryPortSearchByEmbeddingInput[] = [];
+
+  constructor(private readonly graphNodes: GraphNode[]) {}
+
+  findMany(
+    _input: GraphNodeRepositoryPortFindManyInput,
+  ): GraphNodeRepositoryPortFindManyOutput {
+    return Promise.resolve([]);
+  }
+
+  insert(
+    _input: GraphNodeRepositoryPortInsertInput,
+  ): GraphNodeRepositoryPortInsertOutput {
+    return Promise.resolve();
+  }
+
+  searchByEmbedding(
+    input: GraphNodeRepositoryPortSearchByEmbeddingInput,
+  ): GraphNodeRepositoryPortSearchByEmbeddingOutput {
+    this.searchInputs.push(input);
+    return Promise.resolve(this.graphNodes);
+  }
+}
+
+const tenant = "organization:org1";
+const graphId = "01952d3f-0000-7000-8000-000000000100";
+
+const restoreGraph = (): Graph =>
+  Graph.restore({
+    tenant,
+    metadata: {
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    },
+    payload: {
+      id: graphId,
+      embeddingMetadata: {
+        payload: { dimension: "1024", model: "voyage-4-large" },
+      },
+    },
+  });
+
+const restoreGraphNode = (): GraphNode =>
+  GraphNode.restore({
+    tenant,
+    metadata: {
+      createdAt: new Date("2026-01-02T00:00:00Z"),
+      updatedAt: new Date("2026-01-03T00:00:00Z"),
+    },
+    payload: {
+      id: "01952d3f-0000-7000-8000-000000000200",
+      embedding: [0.1, 0.2],
+      eventId: "event-1",
+      graphId,
+      rawEvent: { issue: { key: "REC-1" } },
+    },
+  });
+
+test("SearchGraphUseCase.execute: given a query, it should search graph node embeddings and return raw event DTOs", async () => {
+  const embeddingGateway = new FakeEmbeddingGateway();
+  const graphRepository = new FakeGraphRepository(restoreGraph());
+  const graphNodeRepository = new FakeGraphNodeRepository([restoreGraphNode()]);
+  const useCase = new SearchGraphUseCase(
+    embeddingGateway,
+    graphRepository,
+    graphNodeRepository,
+  );
+
+  const output = await useCase.execute({
+    tenant,
+    payload: { graphId, query: "billing incident" },
+  });
+
+  expect(graphRepository.findByIdInputs).toHaveLength(1);
+  expect(graphRepository.findByIdInputs[0]!.tenant.toString()).toBe(tenant);
+  expect(graphRepository.findByIdInputs[0]!.id.toString()).toBe(graphId);
+  expect(embeddingGateway.embedInputs).toEqual([
+    {
+      model: "voyage-4-large",
+      dimension: "1024",
+      text: "billing incident",
+      inputType: "query",
+    },
+  ]);
+  expect(graphNodeRepository.searchInputs).toHaveLength(1);
+  const searchInput = graphNodeRepository.searchInputs[0]!;
+  expect(searchInput.tenant.toString()).toBe(tenant);
+  expect(searchInput.filters.graphId.toString()).toBe(graphId);
+  expect(searchInput.embedding).toEqual([0.4, 0.5]);
+  expect(searchInput.limit).toBe(10);
+  expect(output).toEqual({ data: [{ rawEvent: { issue: { key: "REC-1" } } }] });
+});
+
+test("SearchGraphUseCase.execute: given a missing graph, it should throw before embedding or search", async () => {
+  const embeddingGateway = new FakeEmbeddingGateway();
+  const graphNodeRepository = new FakeGraphNodeRepository([]);
+  const useCase = new SearchGraphUseCase(
+    embeddingGateway,
+    new FakeGraphRepository(null),
+    graphNodeRepository,
+  );
+
+  const error = await useCase
+    .execute({ tenant, payload: { graphId, query: "billing incident" } })
+    .catch((caught: unknown) => caught);
+
+  expect(error).toHaveProperty("kind", "GraphNotFound");
+  expect(embeddingGateway.embedInputs).toEqual([]);
+  expect(graphNodeRepository.searchInputs).toEqual([]);
+});

--- a/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.ts
@@ -1,0 +1,53 @@
+import { Tenant } from "@repo/server-kernel";
+
+import type {
+  SearchGraphPort,
+  SearchGraphPortInput,
+  SearchGraphPortOutput,
+} from "../ports/inbound/search-graph-port.ts";
+import type { EmbeddingGatewayPort } from "../ports/outbound/embedding-gateway-port.ts";
+import type { GraphNodeRepositoryPort } from "../ports/outbound/graph-node-repository-port.ts";
+import type { GraphRepositoryPort } from "../ports/outbound/graph-repository-port.ts";
+
+import { createGraphNotFoundError } from "../../domain/errors/graph-not-found-error.ts";
+import { GraphId } from "../../domain/value-objects/graph-id.ts";
+
+class SearchGraphUseCase implements SearchGraphPort {
+  constructor(
+    private readonly embeddingGateway: EmbeddingGatewayPort,
+    private readonly graphRepository: GraphRepositoryPort,
+    private readonly graphNodeRepository: GraphNodeRepositoryPort,
+  ) {}
+
+  async execute(input: SearchGraphPortInput): SearchGraphPortOutput {
+    const tenant = Tenant.fromString(input.tenant);
+    const graphId = GraphId.restore({ payload: input.payload.graphId });
+    const graph = await this.graphRepository.findById({ id: graphId, tenant });
+
+    if (graph === null) {
+      throw createGraphNotFoundError("Graph not found", {
+        id: input.payload.graphId,
+        tenant: input.tenant,
+      });
+    }
+
+    const embedding = await this.embeddingGateway.embed({
+      model: graph.embeddingMetadata.model,
+      dimension: graph.embeddingMetadata.dimension,
+      text: input.payload.query,
+      inputType: "query",
+    });
+    const graphNodes = await this.graphNodeRepository.searchByEmbedding({
+      tenant,
+      filters: { graphId },
+      embedding: embedding.embedding,
+      limit: 10,
+    });
+
+    return {
+      data: graphNodes.map((graphNode) => ({ rawEvent: graphNode.rawEvent })),
+    };
+  }
+}
+
+export { SearchGraphUseCase };

--- a/packages/server-knowledge-core/src/index.ts
+++ b/packages/server-knowledge-core/src/index.ts
@@ -9,6 +9,7 @@ export * from "./application/ports/outbound/unit-of-work-port.ts";
 
 export * from "./application/use-cases/list-graph-nodes-use-case.ts";
 export * from "./application/use-cases/process-event-use-case.ts";
+export * from "./application/use-cases/search-graph-use-case.ts";
 
 export * from "./domain/aggregates/graph-node.ts";
 export * from "./domain/aggregates/graph.ts";

--- a/packages/server-knowledge-inbound-adapter/src/http/dtos/graph-node-dtos.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/dtos/graph-node-dtos.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const listGraphNodesPathParams = z.object({
+const graphPathParams = z.object({
   graphId: z.string().trim().min(1),
 });
 
@@ -8,4 +8,8 @@ const listGraphNodesQueryParams = z.object({
   eventId: z.string().trim().min(1),
 });
 
-export { listGraphNodesPathParams, listGraphNodesQueryParams };
+const searchGraphBody = z.object({
+  query: z.string().trim().min(1),
+});
+
+export { graphPathParams, listGraphNodesQueryParams, searchGraphBody };

--- a/packages/server-knowledge-inbound-adapter/src/http/http-server.test.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/http-server.test.ts
@@ -20,3 +20,20 @@ test("createKnowledgeHttpApp: given graph node routes, it should mount them unde
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ graphId: "graph-1" });
 });
+
+test("createKnowledgeHttpApp: given MCP routes, it should mount them under the knowledge API path", async () => {
+  // GIVEN
+  const graphNodeRoutes = new Hono();
+  const mcpRoutes = new Hono();
+  mcpRoutes.post("/mcp", (c) => c.json({ ok: true }));
+  const app = createKnowledgeHttpApp({ deps: { graphNodeRoutes, mcpRoutes } });
+
+  // WHEN
+  const response = await app.request("http://localhost/api/v1/knowledge/mcp", {
+    method: "POST",
+  });
+
+  // THEN
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ ok: true });
+});

--- a/packages/server-knowledge-inbound-adapter/src/http/http-server.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/http-server.ts
@@ -4,6 +4,8 @@ type CreateKnowledgeHttpAppInput = {
   deps: {
     graphNodeRoutes: Hono;
     graphNodeMiddlewares?: readonly MiddlewareHandler[];
+    mcpRoutes?: Hono;
+    mcpMiddlewares?: readonly MiddlewareHandler[];
   };
 };
 
@@ -15,6 +17,14 @@ const createKnowledgeHttpApp = (input: CreateKnowledgeHttpAppInput) => {
   }
 
   app.route("/api/v1/graphs", input.deps.graphNodeRoutes);
+
+  for (const middleware of input.deps.mcpMiddlewares ?? []) {
+    app.use("/api/v1/knowledge/mcp", middleware);
+  }
+
+  if (input.deps.mcpRoutes !== undefined) {
+    app.route("/api/v1/knowledge", input.deps.mcpRoutes);
+  }
 
   return app;
 };

--- a/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.test.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.test.ts
@@ -2,6 +2,9 @@ import type {
   ListGraphNodesPort,
   ListGraphNodesPortInput,
   ListGraphNodesPortOutput,
+  SearchGraphPort,
+  SearchGraphPortInput,
+  SearchGraphPortOutput,
 } from "@repo/server-knowledge-core";
 
 import { expect, test } from "bun:test";
@@ -30,6 +33,15 @@ class FakeListGraphNodes implements ListGraphNodesPort {
   }
 }
 
+class FakeSearchGraph implements SearchGraphPort {
+  readonly executeCalls: SearchGraphPortInput[] = [];
+
+  execute(input: SearchGraphPortInput): SearchGraphPortOutput {
+    this.executeCalls.push(input);
+    return Promise.resolve({ data: [{ rawEvent: graphNode.rawEvent }] });
+  }
+}
+
 class EmptyListGraphNodes implements ListGraphNodesPort {
   execute(): ListGraphNodesPortOutput {
     return Promise.resolve({ data: [] });
@@ -50,7 +62,7 @@ test("createGraphNodeRoutes: given matching graph nodes, it should return the gr
   // GIVEN
   const listGraphNodes = new FakeListGraphNodes();
   const routes = createGraphNodeRoutes({
-    deps: { listGraphNodes },
+    deps: { listGraphNodes, searchGraph: new FakeSearchGraph() },
     resolveTenant: () => tenant,
   });
 
@@ -70,7 +82,10 @@ test("createGraphNodeRoutes: given matching graph nodes, it should return the gr
 test("createGraphNodeRoutes: given no matching graph nodes, it should return an empty list", async () => {
   // GIVEN
   const routes = createGraphNodeRoutes({
-    deps: { listGraphNodes: new EmptyListGraphNodes() },
+    deps: {
+      listGraphNodes: new EmptyListGraphNodes(),
+      searchGraph: new FakeSearchGraph(),
+    },
     resolveTenant: () => tenant,
   });
 
@@ -88,7 +103,7 @@ test("createGraphNodeRoutes: given a missing event id, it should return 422 with
   // GIVEN
   const listGraphNodes = new FakeListGraphNodes();
   const routes = createGraphNodeRoutes({
-    deps: { listGraphNodes },
+    deps: { listGraphNodes, searchGraph: new FakeSearchGraph() },
     resolveTenant: () => tenant,
   });
 
@@ -104,7 +119,10 @@ test("createGraphNodeRoutes: given a missing event id, it should return 422 with
 test("createGraphNodeRoutes: given a malformed tenant rejected by the core, it should return 422", async () => {
   // GIVEN
   const routes = createGraphNodeRoutes({
-    deps: { listGraphNodes: new InvalidListGraphNodes() },
+    deps: {
+      listGraphNodes: new InvalidListGraphNodes(),
+      searchGraph: new FakeSearchGraph(),
+    },
     resolveTenant: () => "malformed",
   });
 
@@ -112,6 +130,53 @@ test("createGraphNodeRoutes: given a malformed tenant rejected by the core, it s
   const response = await routes.request(
     `http://localhost/${graphId}/nodes?eventId=${eventId}&tenant=${tenant}`,
   );
+
+  // THEN
+  expect(response.status).toBe(422);
+  expect(await response.json()).toEqual({ message: "Invalid request" });
+});
+
+test("createGraphNodeRoutes: given a search query, it should return matching raw event DTOs", async () => {
+  // GIVEN
+  const searchGraph = new FakeSearchGraph();
+  const routes = createGraphNodeRoutes({
+    deps: { listGraphNodes: new EmptyListGraphNodes(), searchGraph },
+    resolveTenant: () => tenant,
+  });
+
+  // WHEN
+  const response = await routes.request(`http://localhost/${graphId}/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: "billing incident" }),
+  });
+
+  // THEN
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    data: [{ rawEvent: { issue: { key: "REC-1" } } }],
+  });
+  expect(searchGraph.executeCalls).toEqual([
+    { tenant, payload: { graphId, query: "billing incident" } },
+  ]);
+});
+
+test("createGraphNodeRoutes: given malformed search JSON, it should return 422", async () => {
+  // GIVEN
+  const routes = createGraphNodeRoutes({
+    deps: {
+      listGraphNodes: new EmptyListGraphNodes(),
+      searchGraph: new FakeSearchGraph(),
+    },
+    resolveTenant: () => tenant,
+  });
+
+  // WHEN
+  const response = await routes.request(`http://localhost/${graphId}/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{",
+  });
 
   // THEN
   expect(response.status).toBe(422);

--- a/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/routes/graph-node-routes.ts
@@ -1,11 +1,15 @@
-import type { ListGraphNodesPort } from "@repo/server-knowledge-core";
+import type {
+  ListGraphNodesPort,
+  SearchGraphPort,
+} from "@repo/server-knowledge-core";
 
 import { Hono, type Context } from "hono";
 import { ZodError } from "zod";
 
 import {
-  listGraphNodesPathParams,
+  graphPathParams,
   listGraphNodesQueryParams,
+  searchGraphBody,
 } from "../dtos/graph-node-dtos.ts";
 
 type ResolveTenant = (c: Context) => string;
@@ -13,6 +17,7 @@ type ResolveTenant = (c: Context) => string;
 type CreateGraphNodeRoutesInput = {
   deps: {
     listGraphNodes: ListGraphNodesPort;
+    searchGraph: SearchGraphPort;
   };
   resolveTenant: ResolveTenant;
 };
@@ -32,7 +37,7 @@ const createGraphNodeRoutes = (input: CreateGraphNodeRoutesInput) => {
 
   routes.get("/:graphId/nodes", async (c: Context) => {
     try {
-      const pathParams = listGraphNodesPathParams.parse({
+      const pathParams = graphPathParams.parse({
         graphId: c.req.param("graphId"),
       });
       const queryParams = listGraphNodesQueryParams.parse({
@@ -48,10 +53,27 @@ const createGraphNodeRoutes = (input: CreateGraphNodeRoutesInput) => {
 
       return c.json(graphNodes);
     } catch (error) {
-      if (
-        error instanceof ZodError ||
-        (isCategorizedError(error) && error.category === "validation")
-      ) {
+      if (isValidationError(error)) {
+        return c.json({ message: "Invalid request" }, 422);
+      }
+      throw error;
+    }
+  });
+
+  routes.post("/:graphId/search", async (c: Context) => {
+    try {
+      const pathParams = graphPathParams.parse({
+        graphId: c.req.param("graphId"),
+      });
+      const body = searchGraphBody.parse(await c.req.json());
+      const results = await input.deps.searchGraph.execute({
+        tenant: input.resolveTenant(c),
+        payload: { graphId: pathParams.graphId, query: body.query },
+      });
+
+      return c.json(results);
+    } catch (error) {
+      if (isValidationError(error)) {
         return c.json({ message: "Invalid request" }, 422);
       }
       throw error;
@@ -60,5 +82,10 @@ const createGraphNodeRoutes = (input: CreateGraphNodeRoutesInput) => {
 
   return routes;
 };
+
+const isValidationError = (error: unknown): boolean =>
+  error instanceof SyntaxError ||
+  error instanceof ZodError ||
+  (isCategorizedError(error) && error.category === "validation");
 
 export { createGraphNodeRoutes };

--- a/packages/server-knowledge-inbound-adapter/src/http/routes/mcp-routes.test.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/routes/mcp-routes.test.ts
@@ -1,0 +1,120 @@
+import type {
+  SearchGraphPort,
+  SearchGraphPortInput,
+  SearchGraphPortOutput,
+} from "@repo/server-knowledge-core";
+
+import { expect, test } from "bun:test";
+
+import { createKnowledgeMcpRoutes } from "./mcp-routes.ts";
+
+const tenant = "organization:org1";
+const graphId = "01952d3f-0000-7000-8000-000000000100";
+
+class FakeSearchGraph implements SearchGraphPort {
+  readonly executeCalls: SearchGraphPortInput[] = [];
+
+  execute(input: SearchGraphPortInput): SearchGraphPortOutput {
+    this.executeCalls.push(input);
+    return Promise.resolve({
+      data: [{ rawEvent: { issue: { key: "REC-1" } } }],
+    });
+  }
+}
+
+test("createKnowledgeMcpRoutes: given a tool list request, it should expose search knowledge", async () => {
+  const routes = createKnowledgeMcpRoutes({
+    deps: { searchGraph: new FakeSearchGraph() },
+    resolveTenant: () => tenant,
+  });
+
+  const response = await routes.request("http://localhost/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      tools: [
+        {
+          name: "search_knowledge",
+          description: "Search graph nodes by semantic query.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              graphId: { type: "string" },
+              query: { type: "string" },
+            },
+            required: ["graphId", "query"],
+          },
+        },
+      ],
+    },
+  });
+});
+
+test("createKnowledgeMcpRoutes: given a search knowledge tool call, it should return raw event DTOs", async () => {
+  const searchGraph = new FakeSearchGraph();
+  const routes = createKnowledgeMcpRoutes({
+    deps: { searchGraph },
+    resolveTenant: () => tenant,
+  });
+
+  const response = await routes.request("http://localhost/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "call-1",
+      method: "tools/call",
+      params: {
+        name: "search_knowledge",
+        arguments: { graphId, query: "billing incident" },
+      },
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    jsonrpc: "2.0",
+    id: "call-1",
+    result: {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: [{ rawEvent: { issue: { key: "REC-1" } } }],
+          }),
+        },
+      ],
+      structuredContent: { data: [{ rawEvent: { issue: { key: "REC-1" } } }] },
+    },
+  });
+  expect(searchGraph.executeCalls).toEqual([
+    { tenant, payload: { graphId, query: "billing incident" } },
+  ]);
+});
+
+test("createKnowledgeMcpRoutes: given malformed JSON, it should return a JSON-RPC parse error", async () => {
+  const routes = createKnowledgeMcpRoutes({
+    deps: { searchGraph: new FakeSearchGraph() },
+    resolveTenant: () => tenant,
+  });
+
+  const response = await routes.request("http://localhost/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{",
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    jsonrpc: "2.0",
+    id: null,
+    error: { code: -32700, message: "Parse error" },
+  });
+});

--- a/packages/server-knowledge-inbound-adapter/src/http/routes/mcp-routes.ts
+++ b/packages/server-knowledge-inbound-adapter/src/http/routes/mcp-routes.ts
@@ -1,0 +1,129 @@
+import type { SearchGraphPort } from "@repo/server-knowledge-core";
+
+import { Hono, type Context } from "hono";
+import { z, ZodError } from "zod";
+
+type ResolveTenant = (c: Context) => string;
+
+type CreateKnowledgeMcpRoutesInput = {
+  deps: { searchGraph: SearchGraphPort };
+  resolveTenant: ResolveTenant;
+};
+
+const rpcRequestBody = z.object({
+  id: z.union([z.string(), z.number(), z.null()]).optional(),
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+const toolCallParams = z.object({
+  name: z.literal("search_knowledge"),
+  arguments: z.object({
+    graphId: z.string().trim().min(1),
+    query: z.string().trim().min(1),
+  }),
+});
+
+const createKnowledgeMcpRoutes = (input: CreateKnowledgeMcpRoutesInput) => {
+  const routes = new Hono();
+
+  routes.post("/mcp", async (c: Context) => {
+    const parsedRequest = await parseRpcRequest(c);
+
+    if (!parsedRequest.success) {
+      return c.json({
+        jsonrpc: "2.0",
+        id: null,
+        error: parsedRequest.error,
+      });
+    }
+
+    const request = parsedRequest.data;
+
+    if (request.method === "tools/list") {
+      return c.json({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        result: {
+          tools: [
+            {
+              name: "search_knowledge",
+              description: "Search graph nodes by semantic query.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  graphId: { type: "string" },
+                  query: { type: "string" },
+                },
+                required: ["graphId", "query"],
+              },
+            },
+          ],
+        },
+      });
+    }
+
+    if (request.method === "tools/call") {
+      try {
+        const params = toolCallParams.parse(request.params);
+        const result = await input.deps.searchGraph.execute({
+          tenant: input.resolveTenant(c),
+          payload: params.arguments,
+        });
+
+        return c.json({
+          jsonrpc: "2.0",
+          id: request.id ?? null,
+          result: {
+            content: [{ type: "text", text: JSON.stringify(result) }],
+            structuredContent: result,
+          },
+        });
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return c.json({
+            jsonrpc: "2.0",
+            id: request.id ?? null,
+            error: { code: -32602, message: "Invalid params" },
+          });
+        }
+        throw error;
+      }
+    }
+
+    return c.json({
+      jsonrpc: "2.0",
+      id: request.id ?? null,
+      error: { code: -32601, message: "Method not found" },
+    });
+  });
+
+  return routes;
+};
+
+const parseRpcRequest = async (
+  c: Context,
+): Promise<
+  | { success: true; data: z.infer<typeof rpcRequestBody> }
+  | { success: false; error: { code: number; message: string } }
+> => {
+  try {
+    return { success: true, data: rpcRequestBody.parse(await c.req.json()) };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {
+        success: false,
+        error: { code: -32700, message: "Parse error" },
+      };
+    }
+    if (error instanceof ZodError) {
+      return {
+        success: false,
+        error: { code: -32600, message: "Invalid request" },
+      };
+    }
+    throw error;
+  }
+};
+
+export { createKnowledgeMcpRoutes };

--- a/packages/server-knowledge-inbound-adapter/src/index.ts
+++ b/packages/server-knowledge-inbound-adapter/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./http/http-server.ts";
 export * from "./http/routes/graph-node-routes.ts";
+export * from "./http/routes/mcp-routes.ts";
 
 export * from "./mongodb/mongodb-change-stream.ts";

--- a/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.test.ts
+++ b/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.test.ts
@@ -25,6 +25,7 @@ test("VoyageaiEmbeddingGateway.embed: given text, it should request and return i
     dimension: "1024",
     model: "voyage-4-large",
     text: "event",
+    inputType: "document",
   });
 
   // THEN
@@ -60,6 +61,7 @@ test("VoyageaiEmbeddingGateway.embed: given an unsuccessful response, it should 
       dimension: "1024",
       model: "voyage-4-large",
       text: "event",
+      inputType: "document",
     }),
   ).rejects.toThrow("Voyage AI embedding request failed with status 429");
 });
@@ -82,6 +84,7 @@ test("VoyageaiEmbeddingGateway.embed: given a custom base URL, it should request
     dimension: "1024",
     model: "voyage-4-large",
     text: "event",
+    inputType: "document",
   });
 
   // THEN

--- a/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.ts
+++ b/packages/server-knowledge-outbound-adapter/src/embedding/voyageai/voyageai-embedding-gateway.ts
@@ -39,7 +39,7 @@ class VoyageaiEmbeddingGateway implements EmbeddingGatewayPort {
       },
       body: JSON.stringify({
         input: input.text,
-        input_type: "document",
+        input_type: input.inputType,
         model: input.model,
         output_dimension: Number(input.dimension),
       }),

--- a/packages/server-knowledge-outbound-adapter/src/persistence/mongodb/mongodb-graph-node-repository.test.ts
+++ b/packages/server-knowledge-outbound-adapter/src/persistence/mongodb/mongodb-graph-node-repository.test.ts
@@ -1,4 +1,10 @@
-import type { ClientSession, Collection, Filter, MongoClient } from "mongodb";
+import type {
+  ClientSession,
+  Collection,
+  Document,
+  Filter,
+  MongoClient,
+} from "mongodb";
 
 import { Tenant } from "@repo/server-kernel";
 import { EventId, GraphId, GraphNode } from "@repo/server-knowledge-core";
@@ -12,6 +18,9 @@ type InsertOneOptions = Parameters<
   Collection<MongodbGraphNodeModel>["insertOne"]
 >[1];
 type FindOptions = Parameters<Collection<MongodbGraphNodeModel>["find"]>[1];
+type AggregateOptions = Parameters<
+  Collection<MongodbGraphNodeModel>["aggregate"]
+>[1];
 
 class FakeCollection {
   readonly calls: {
@@ -22,7 +31,12 @@ class FakeCollection {
     filter: Filter<MongodbGraphNodeModel>;
     options: FindOptions;
   }[] = [];
+  readonly aggregateCalls: {
+    pipeline: Document[];
+    options: AggregateOptions;
+  }[] = [];
   findResult: MongodbGraphNodeModel[] = [];
+  aggregateResult: MongodbGraphNodeModel[] = [];
   error?: Error;
 
   find(
@@ -31,6 +45,14 @@ class FakeCollection {
   ): { toArray: () => Promise<MongodbGraphNodeModel[]> } {
     this.findCalls.push({ filter, options });
     return { toArray: () => Promise.resolve(this.findResult) };
+  }
+
+  aggregate(
+    pipeline: Document[],
+    options: AggregateOptions,
+  ): { toArray: () => Promise<MongodbGraphNodeModel[]> } {
+    this.aggregateCalls.push({ pipeline, options });
+    return { toArray: () => Promise.resolve(this.aggregateResult) };
   }
 
   insertOne(
@@ -191,4 +213,56 @@ test("MongodbGraphNodeRepository.insert: given an insert error, it should rethro
 
   // THEN
   expect(error).toBe(thrown);
+});
+
+test("MongodbGraphNodeRepository.searchByEmbedding: given tenant and graph id, it should run a limited vector search", async () => {
+  // GIVEN
+  const client = new FakeMongoClient();
+  const session = { id: "session-1" } as unknown as ClientSession;
+  client.collection.aggregateResult = [
+    {
+      _id: "node-1",
+      createdAt,
+      updatedAt,
+      tenant,
+      embedding: [0.1, 0.2],
+      eventId,
+      graphId,
+      rawEvent: { issue: { key: eventId } },
+    },
+  ];
+  const repository = new MongodbGraphNodeRepository(
+    client as unknown as MongoClient,
+    "recallos",
+    session,
+  );
+
+  // WHEN
+  const nodes = await repository.searchByEmbedding({
+    tenant: Tenant.fromString(tenant),
+    filters: { graphId: GraphId.restore({ payload: graphId }) },
+    embedding: [0.4, 0.5],
+    limit: 25,
+  });
+
+  // THEN
+  expect(client.collection.aggregateCalls).toEqual([
+    {
+      pipeline: [
+        {
+          $vectorSearch: {
+            index: "graph_node_embedding",
+            path: "embedding",
+            queryVector: [0.4, 0.5],
+            limit: 10,
+            numCandidates: 100,
+            filter: { graphId, tenant },
+          },
+        },
+      ],
+      options: { session },
+    },
+  ]);
+  expect(nodes).toHaveLength(1);
+  expect(nodes[0]!.rawEvent).toEqual({ issue: { key: eventId } });
 });

--- a/packages/server-knowledge-outbound-adapter/src/persistence/mongodb/mongodb-graph-node-repository.ts
+++ b/packages/server-knowledge-outbound-adapter/src/persistence/mongodb/mongodb-graph-node-repository.ts
@@ -4,6 +4,8 @@ import type {
   GraphNodeRepositoryPortFindManyOutput,
   GraphNodeRepositoryPortInsertInput,
   GraphNodeRepositoryPortInsertOutput,
+  GraphNodeRepositoryPortSearchByEmbeddingInput,
+  GraphNodeRepositoryPortSearchByEmbeddingOutput,
 } from "@repo/server-knowledge-core";
 import type { Collection, ClientSession, MongoClient } from "mongodb";
 
@@ -34,22 +36,34 @@ class MongodbGraphNodeRepository implements GraphNodeRepositoryPort {
       )
       .toArray();
 
-    return models.map((model) =>
-      GraphNode.restore({
-        tenant: model.tenant,
-        metadata: {
-          createdAt: model.createdAt,
-          updatedAt: model.updatedAt,
-        },
-        payload: {
-          id: model._id,
-          embedding: model.embedding,
-          eventId: model.eventId,
-          graphId: model.graphId,
-          rawEvent: model.rawEvent,
-        },
-      }),
-    );
+    return this.restoreGraphNodes(models);
+  }
+
+  async searchByEmbedding(
+    input: GraphNodeRepositoryPortSearchByEmbeddingInput,
+  ): GraphNodeRepositoryPortSearchByEmbeddingOutput {
+    const models = await this.collection
+      .aggregate<MongodbGraphNodeModel>(
+        [
+          {
+            $vectorSearch: {
+              index: "graph_node_embedding",
+              path: "embedding",
+              queryVector: input.embedding,
+              limit: Math.min(input.limit, 10),
+              numCandidates: 100,
+              filter: {
+                graphId: input.filters.graphId.toString(),
+                tenant: input.tenant.toString(),
+              },
+            },
+          },
+        ],
+        { session: this.session },
+      )
+      .toArray();
+
+    return this.restoreGraphNodes(models);
   }
 
   async insert(
@@ -68,6 +82,25 @@ class MongodbGraphNodeRepository implements GraphNodeRepositoryPort {
     } satisfies MongodbGraphNodeModel;
 
     await this.collection.insertOne(model, { session: this.session });
+  }
+
+  private restoreGraphNodes(models: MongodbGraphNodeModel[]): GraphNode[] {
+    return models.map((model) =>
+      GraphNode.restore({
+        tenant: model.tenant,
+        metadata: {
+          createdAt: model.createdAt,
+          updatedAt: model.updatedAt,
+        },
+        payload: {
+          id: model._id,
+          embedding: model.embedding,
+          eventId: model.eventId,
+          graphId: model.graphId,
+          rawEvent: model.rawEvent,
+        },
+      }),
+    );
   }
 
   private get collection(): Collection<MongodbGraphNodeModel> {


### PR DESCRIPTION
### Motivation

- Wire a minimal embedding-based search over graph nodes so callers can semantically query a graph and receive matching raw node DTOs.
- Keep the implementation simple and hexagonal: a core use case, an outbound MongoDB vector search, inbound HTTP + MCP entrypoints, and API-key based auth.
- Limit returned results to a maximum of 10 and surface raw transport DTOs (no embeddings) for API/MCP consumers.

### Description

- Added `SearchGraphUseCase` in `packages/server-knowledge-core` that verifies the graph exists, obtains its embedding metadata, embeds the search query, runs a search, and returns `{ data: [{ rawEvent }] }`. (`packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.ts`).
- Extended core ports: added `searchByEmbedding` to `GraphNodeRepositoryPort` and an `inputType` on `EmbeddingGatewayPort` so search uses query embeddings and ingestion uses document embeddings. (ports updated under `packages/server-knowledge-core/src/application/ports/...`).
- Implemented MongoDB vector search in the outbound adapter using `$vectorSearch` with tenant + graph filters, `numCandidates: 100`, and `limit: Math.min(requested, 10)`, and restored results to domain `GraphNode`s. (`packages/server-knowledge-outbound-adapter/src/persistence/mongodb/mongodb-graph-node-repository.ts`).
- Exposed HTTP search endpoint `POST /api/v1/graphs/:graphId/search` with request validation and malformed-JSON -> `422` mapping, and added an MCP JSON-RPC style `/mcp` route that lists and invokes a `search_knowledge` tool, mapping JSON-RPC parse/validation errors. (`packages/server-knowledge-inbound-adapter/src/http/routes/*`).
- Wired everything in the `server-api` composition root: added `Voyageai` config, instantiated `MongodbGraphRepository`, `MongodbGraphNodeRepository`, `VoyageaiEmbeddingGateway`, `SearchGraphUseCase`, and mounted the HTTP + MCP routes with the existing `requireKnowledgeRead` API-key middleware. (`apps/server-api/src/knowledge.ts`, `apps/server-api/src/config.ts`).
- Added unit tests for the new use case, inbound routes, MCP routes, and repository vector-search behavior, and updated related tests to account for the new ports and input types.

### Testing

- Ran formatting with `mise x bun@1.3.14 -- bun run fmt`, which completed successfully.
- Ran unit tests for the affected packages with `mise x bun@1.3.14 -- bun run test --filter ./packages/server-knowledge-core --filter ./packages/server-knowledge-inbound-adapter --filter ./packages/server-knowledge-outbound-adapter --filter ./apps/server-api`, and the test suite for those packages passed (new tests for `SearchGraphUseCase`, inbound routes, MCP routes, and MongoDB vector search were included and passed).
- Performed focused lint/build steps and a full build with `mise x bun@1.3.14 -- bun run build --filter ./packages/server-knowledge-core --filter ./packages/server-knowledge-inbound-adapter --filter ./packages/server-knowledge-outbound-adapter --filter ./apps/server-api`, which completed successfully; an earlier aggregated lint run surfaced an existing TypeScript diagnostic in `@repo/server-kernel` unrelated to these changes, which was reported during the rollout but did not block the packaged tests nor the build.
- Verified `git diff --check` and ensured no leftover formatting or check errors remained before creating the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed0dc8648832d9c0609678cee6173)