### PR TITLE
refactor: address search graph review comment

### DIFF
--- a/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.ts
+++ b/packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.ts
@@ -31,7 +31,7 @@ class SearchGraphUseCase implements SearchGraphPort {
       });
     }
 
-    const embedding = await this.embeddingGateway.embed({
+    const embedResult = await this.embeddingGateway.embed({
       model: graph.embeddingMetadata.model,
       dimension: graph.embeddingMetadata.dimension,
       text: input.payload.query,
@@ -40,7 +40,7 @@ class SearchGraphUseCase implements SearchGraphPort {
     const graphNodes = await this.graphNodeRepository.searchByEmbedding({
       tenant,
       filters: { graphId },
-      embedding: embedding.embedding,
+      embedding: embedResult.embedding,
       limit: 10,
     });
 


### PR DESCRIPTION
Source PR: #66

Addressed comments:
- PR #66 review thread PRRT_kwDOSlSOnc6MpG1y / comment 3484280042: renamed the search graph embedding result local variable to `embedResult`.

Verification:
- `bun test packages/server-knowledge-core/src/application/use-cases/search-graph-use-case.test.ts` (2 pass, 0 fail, 13 expect calls)
- `git diff --check`